### PR TITLE
app.run_server was replaced by app.run as its obsolete

### DIFF
--- a/pymotion/render/viewer.py
+++ b/pymotion/render/viewer.py
@@ -122,7 +122,7 @@ class Viewer:
         # Check for debugging environment to avoid duplicated browser tabs
         if not os.environ.get("WERKZEUG_RUN_MAIN"):
             webbrowser.open_new("http://localhost:8050")
-        self.app.run_server(debug=True, use_reloader=self.use_reloader)
+        self.app.run(debug=True, use_reloader=self.use_reloader)
 
     def add_skeleton(
         self,


### PR DESCRIPTION
The built in Viewer spit out this error at me so i went and fixed it real quick. The comment at the end of the chain said to use app.run instead of app.run_server. So thats what i did. 