### PR TITLE
Add unified NumPy/PyTorch backend dispatchers

### DIFF
--- a/pymotion/io/bvh.py
+++ b/pymotion/io/bvh.py
@@ -1,6 +1,10 @@
-import numpy as np
-import pymotion.rotations.quat as quat
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import copy
+import os
+
+import numpy as np
+import pymotion.rotations.quat_np as quat
 
 
 class BVH:
@@ -21,19 +25,21 @@ class BVH:
         """
         self.data = copy.deepcopy(bvh.data)
 
-    def load(self, filename: str):
+    def load(self, filepath: str):
         """
         Reads a BVH file and returns a dictionary with the data.
 
         Parameters
         ----------
-        filename : str
+        filepath : str
             path to the file.
 
         Results
         ------
         self.data : dict
             dictionary with the data.
+            ["filename"] : str
+                name of the file.
             ["names"] : np.array[str]
                 ith-element contain the name of ith-joint.
             ["offsets"] : np.array[n_joints, 3]
@@ -52,8 +58,13 @@ class BVH:
                 local rotations in euler angles with the order specified in rot_order.
             ["frame_time"] : float
                 time between two frames in seconds.
+            ["channels"] : np.array[int]
+                ith-element contain the number of channels of the ith joint.
         """
-        f = open(filename, "r")
+        f = open(filepath, "r")
+        filename = os.path.basename(filepath)
+        filename = filename.split(".")[:-1]
+        filename = ".".join(filename)
 
         names = []
         offsets = []
@@ -109,10 +120,16 @@ class BVH:
                     number_channels = int(words[1])
                     channels[current] = number_channels
                     if number_channels == 6:
-                        position_order[current] = [self.bvh_pos_map_num[x] for x in words[2 : 2 + 3]]
-                        rot_order[current] = [self.bvh_rot_map[x] for x in words[2 + 3 : 2 + 3 + 3]]
+                        position_order[current] = [
+                            self.bvh_pos_map_num[x] for x in words[2 : 2 + 3]
+                        ]
+                        rot_order[current] = [
+                            self.bvh_rot_map[x] for x in words[2 + 3 : 2 + 3 + 3]
+                        ]
                     elif number_channels == 3:
-                        rot_order[current] = [self.bvh_rot_map[x] for x in words[2 : 2 + 3]]
+                        rot_order[current] = [
+                            self.bvh_rot_map[x] for x in words[2 : 2 + 3]
+                        ]
                     else:
                         raise Exception("Unknown number of channels")
                     continue
@@ -126,7 +143,10 @@ class BVH:
                     end_sites = np.array(end_sites)
                     end_sites_parents = np.array(end_sites_parents)
                     rot_order = np.array(rot_order)
-                    positions = np.tile(offsets, (number_frames, 1)).reshape(number_frames, len(offsets), 3)
+                    channels = np.array(channels)
+                    positions = np.tile(offsets, (number_frames, 1)).reshape(
+                        number_frames, len(offsets), 3
+                    )
                     rotations = np.zeros((number_frames, len(names), 3))
                     continue
 
@@ -149,12 +169,14 @@ class BVH:
         f.close()
 
         self.data = {
+            "filename": filename,
             "names": names,
             "offsets": offsets,
             "end_sites": end_sites,
             "end_sites_parents": end_sites_parents,
             "parents": parents,
             "rot_order": rot_order,
+            "channels": channels,  # TODO: properly handle different positional channels and orders
             "positions": positions,
             "rotations": rotations,
             "frame_time": frame_time,
@@ -216,7 +238,9 @@ class BVH:
 
             for i in range(self.data["positions"].shape[0]):
                 for j in joint_order:
-                    if j == 0:  # root
+                    if (
+                        self.data["channels"][j] == 6
+                    ):  # joint has position and rotation channels
                         f.write(
                             "%f %f %f "
                             % (
@@ -260,9 +284,13 @@ class BVH:
 
         reverse_order = [order.index(i) for i in range(len(order))]
 
-        self.data["names"] = np.array([self.data["names"][reverse_order[i]] for i in range(len(order))])
+        self.data["names"] = np.array(
+            [self.data["names"][reverse_order[i]] for i in range(len(order))]
+        )
         self.data["offsets"] = self.data["offsets"][reverse_order]
-        self.data["end_sites_parents"] = np.array([order[j] for j in self.data["end_sites_parents"]])
+        self.data["end_sites_parents"] = np.array(
+            [order[j] for j in self.data["end_sites_parents"]]
+        )
         self.data["parents"] = np.array(
             [order[self.data["parents"][reverse_order[i]]] for i in range(len(order))]
         )
@@ -281,7 +309,11 @@ class BVH:
         """
 
         # Identify joints to keep
-        keep_joints = [i for i in range(len(self.data["names"])) if i not in delete_joints]
+        delete_joints_set = set(delete_joints)
+        keep_joints = [
+            i for i in range(len(self.data["names"])) if i not in delete_joints_set
+        ]
+        keep_joints_set = set(keep_joints)
         new_to_old = dict(enumerate(keep_joints))
         old_to_new = dict((v, k) for k, v in new_to_old.items())
 
@@ -291,30 +323,42 @@ class BVH:
         new_pos = pos[:, keep_joints, :]
         new_offsets = offsets[keep_joints, :]
         for j in keep_joints:
-            while parents[j] not in keep_joints:
+            while parents[j] not in keep_joints_set:
                 p = parents[j]
-                new_rots[:, old_to_new[j], :] = quat.mul(rots[:, p, :], new_rots[:, old_to_new[j], :])
+                new_rots[:, old_to_new[j], :] = quat.mul(
+                    rots[:, p, :], new_rots[:, old_to_new[j], :]
+                )
                 new_pos[:, old_to_new[j], :] = (
-                    quat.mul_vec(rots[:, p, :], new_pos[:, old_to_new[j], :]) + pos[:, p, :]
+                    quat.mul_vec(rots[:, p, :], new_pos[:, old_to_new[j], :])
+                    + pos[:, p, :]
                 )
                 new_offsets[old_to_new[j]] = (
                     quat.mul_vec(rots[0, p, :], new_offsets[old_to_new[j]]) + offsets[p]
                 )
-                parents[j] = parents[p]
+                if parents[j] == 0:
+                    # root
+                    parents[j] = j
+                    break
+                else:
+                    parents[j] = parents[p]
 
         # Update parent indices for remaining joints
         new_parents = [0] * len(keep_joints)
         for i, p in enumerate(parents):
-            if i in keep_joints:
+            if i in keep_joints_set:
                 new_parents[old_to_new[i]] = old_to_new[p]
 
         # Update end_sites_parents to reflect the removal of joints
         updated_end_sites_parents = [
-            old_to_new[es_parent] for es_parent in end_sites_parents if es_parent in old_to_new
+            old_to_new[es_parent]
+            for es_parent in end_sites_parents
+            if es_parent in old_to_new
         ]
         # Remove end sites associated with deleted joints, if necessary
         valid_end_sites_indices = [
-            i for i, es_parent in enumerate(end_sites_parents) if es_parent not in delete_joints
+            i
+            for i, es_parent in enumerate(end_sites_parents)
+            if es_parent not in delete_joints
         ]
 
         # Update data
@@ -322,7 +366,9 @@ class BVH:
         self.data["rot_order"] = self.data["rot_order"][..., keep_joints, :]
         self.data["positions"] = new_pos
         self.data["rotations"] = np.degrees(
-            quat.to_euler(new_rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1)))
+            quat.to_euler(
+                new_rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1))
+            )
         )
         self.data["parents"] = np.array(new_parents)
         self.data["offsets"] = new_offsets
@@ -352,7 +398,9 @@ class BVH:
         rots = quat.unroll(
             quat.from_euler(
                 np.radians(self.data["rotations"]),
-                order=np.tile(self.data["rot_order"], (self.data["rotations"].shape[0], 1, 1)),
+                order=np.tile(
+                    self.data["rot_order"], (self.data["rotations"].shape[0], 1, 1)
+                ),
             ),
             axis=0,
         )
@@ -384,9 +432,42 @@ class BVH:
         ), "load a BVH file first or create a self.data dict with the same structure as the one returned by load(...)"
 
         self.data["rotations"] = np.degrees(
-            quat.to_euler(rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1)))
+            quat.to_euler(
+                rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1))
+            )
         )
         self.data["positions"] = pos
+
+    def set_rotation_order(self, new_order: str):
+        """
+        Changes the rotation order of all joints in the BVH.
+        Converts rotations from the current order to the new order.
+
+        Parameters
+        ----------
+        new_order : str
+            New rotation order, e.g., 'xyz', 'zyx', 'zxy', etc.
+            Must be a 3-character string containing 'x', 'y', and 'z'.
+        """
+        new_order = new_order.lower()
+        assert len(new_order) == 3, "Rotation order must be a 3-character string"
+        assert set(new_order) == {
+            "x",
+            "y",
+            "z",
+        }, "Rotation order must contain 'x', 'y', and 'z'"
+
+        # Get current data (converts euler angles to quaternions using current order)
+        rots, pos, _, _, _, _ = self.get_data()
+
+        # Update rotation order for all joints
+        new_rot_order = np.array(
+            [[c for c in new_order] for _ in range(len(self.data["names"]))]
+        )
+        self.data["rot_order"] = new_rot_order
+
+        # Set data back (converts quaternions to euler angles using new order)
+        self.set_data(rots, pos)
 
     def _save_joint(self, f, data, tab, i, joint_order):
         joint_order.append(i)
@@ -404,15 +485,27 @@ class BVH:
                 data["offsets"][i, 2],
             )
         )
-        f.write(
-            "%sCHANNELS 3 %s %s %s\n"
-            % (
-                tab,
-                self.inv_bvh_rot_map[data["rot_order"][i, 0]],
-                self.inv_bvh_rot_map[data["rot_order"][i, 1]],
-                self.inv_bvh_rot_map[data["rot_order"][i, 2]],
+
+        if data["channels"][i] == 6:  # joint has position and rotation channels
+            f.write(
+                "%sCHANNELS 6 Xposition Yposition Zposition %s %s %s \n"
+                % (
+                    tab,
+                    self.inv_bvh_rot_map[self.data["rot_order"][0, 0]],
+                    self.inv_bvh_rot_map[self.data["rot_order"][0, 1]],
+                    self.inv_bvh_rot_map[self.data["rot_order"][0, 2]],
+                )
             )
-        )
+        else:  # joint has only rotation channels
+            f.write(
+                "%sCHANNELS 3 %s %s %s\n"
+                % (
+                    tab,
+                    self.inv_bvh_rot_map[data["rot_order"][i, 0]],
+                    self.inv_bvh_rot_map[data["rot_order"][i, 1]],
+                    self.inv_bvh_rot_map[data["rot_order"][i, 2]],
+                )
+            )
 
         is_end_site = True
 
@@ -426,12 +519,19 @@ class BVH:
             f.write("%s{\n" % tab)
             tab += "\t"
             try:
-                end_site_data = data["end_sites"][np.where(data["end_sites_parents"] == i)[0][0]]
+                end_site_data = data["end_sites"][
+                    np.where(data["end_sites_parents"] == i)[0][0]
+                ]
             except ValueError:
                 end_site_data = np.zeros(3)
             except KeyError:
                 end_site_data = np.zeros(3)
-            f.write("%sOFFSET %f %f %f\n" % (tab, end_site_data[0], end_site_data[1], end_site_data[2]))
+            except IndexError:
+                end_site_data = np.zeros(3)
+            f.write(
+                "%sOFFSET %f %f %f\n"
+                % (tab, end_site_data[0], end_site_data[1], end_site_data[2])
+            )
             tab = tab[:-1]
             f.write("%s}\n" % tab)
 

--- a/pymotion/io/bvh.py
+++ b/pymotion/io/bvh.py
@@ -120,16 +120,10 @@ class BVH:
                     number_channels = int(words[1])
                     channels[current] = number_channels
                     if number_channels == 6:
-                        position_order[current] = [
-                            self.bvh_pos_map_num[x] for x in words[2 : 2 + 3]
-                        ]
-                        rot_order[current] = [
-                            self.bvh_rot_map[x] for x in words[2 + 3 : 2 + 3 + 3]
-                        ]
+                        position_order[current] = [self.bvh_pos_map_num[x] for x in words[2 : 2 + 3]]
+                        rot_order[current] = [self.bvh_rot_map[x] for x in words[2 + 3 : 2 + 3 + 3]]
                     elif number_channels == 3:
-                        rot_order[current] = [
-                            self.bvh_rot_map[x] for x in words[2 : 2 + 3]
-                        ]
+                        rot_order[current] = [self.bvh_rot_map[x] for x in words[2 : 2 + 3]]
                     else:
                         raise Exception("Unknown number of channels")
                     continue
@@ -144,9 +138,7 @@ class BVH:
                     end_sites_parents = np.array(end_sites_parents)
                     rot_order = np.array(rot_order)
                     channels = np.array(channels)
-                    positions = np.tile(offsets, (number_frames, 1)).reshape(
-                        number_frames, len(offsets), 3
-                    )
+                    positions = np.tile(offsets, (number_frames, 1)).reshape(number_frames, len(offsets), 3)
                     rotations = np.zeros((number_frames, len(names), 3))
                     continue
 
@@ -238,9 +230,7 @@ class BVH:
 
             for i in range(self.data["positions"].shape[0]):
                 for j in joint_order:
-                    if (
-                        self.data["channels"][j] == 6
-                    ):  # joint has position and rotation channels
+                    if self.data["channels"][j] == 6:  # joint has position and rotation channels
                         f.write(
                             "%f %f %f "
                             % (
@@ -284,13 +274,9 @@ class BVH:
 
         reverse_order = [order.index(i) for i in range(len(order))]
 
-        self.data["names"] = np.array(
-            [self.data["names"][reverse_order[i]] for i in range(len(order))]
-        )
+        self.data["names"] = np.array([self.data["names"][reverse_order[i]] for i in range(len(order))])
         self.data["offsets"] = self.data["offsets"][reverse_order]
-        self.data["end_sites_parents"] = np.array(
-            [order[j] for j in self.data["end_sites_parents"]]
-        )
+        self.data["end_sites_parents"] = np.array([order[j] for j in self.data["end_sites_parents"]])
         self.data["parents"] = np.array(
             [order[self.data["parents"][reverse_order[i]]] for i in range(len(order))]
         )
@@ -310,9 +296,7 @@ class BVH:
 
         # Identify joints to keep
         delete_joints_set = set(delete_joints)
-        keep_joints = [
-            i for i in range(len(self.data["names"])) if i not in delete_joints_set
-        ]
+        keep_joints = [i for i in range(len(self.data["names"])) if i not in delete_joints_set]
         keep_joints_set = set(keep_joints)
         new_to_old = dict(enumerate(keep_joints))
         old_to_new = dict((v, k) for k, v in new_to_old.items())
@@ -325,12 +309,9 @@ class BVH:
         for j in keep_joints:
             while parents[j] not in keep_joints_set:
                 p = parents[j]
-                new_rots[:, old_to_new[j], :] = quat.mul(
-                    rots[:, p, :], new_rots[:, old_to_new[j], :]
-                )
+                new_rots[:, old_to_new[j], :] = quat.mul(rots[:, p, :], new_rots[:, old_to_new[j], :])
                 new_pos[:, old_to_new[j], :] = (
-                    quat.mul_vec(rots[:, p, :], new_pos[:, old_to_new[j], :])
-                    + pos[:, p, :]
+                    quat.mul_vec(rots[:, p, :], new_pos[:, old_to_new[j], :]) + pos[:, p, :]
                 )
                 new_offsets[old_to_new[j]] = (
                     quat.mul_vec(rots[0, p, :], new_offsets[old_to_new[j]]) + offsets[p]
@@ -350,15 +331,11 @@ class BVH:
 
         # Update end_sites_parents to reflect the removal of joints
         updated_end_sites_parents = [
-            old_to_new[es_parent]
-            for es_parent in end_sites_parents
-            if es_parent in old_to_new
+            old_to_new[es_parent] for es_parent in end_sites_parents if es_parent in old_to_new
         ]
         # Remove end sites associated with deleted joints, if necessary
         valid_end_sites_indices = [
-            i
-            for i, es_parent in enumerate(end_sites_parents)
-            if es_parent not in delete_joints
+            i for i, es_parent in enumerate(end_sites_parents) if es_parent not in delete_joints
         ]
 
         # Update data
@@ -366,9 +343,7 @@ class BVH:
         self.data["rot_order"] = self.data["rot_order"][..., keep_joints, :]
         self.data["positions"] = new_pos
         self.data["rotations"] = np.degrees(
-            quat.to_euler(
-                new_rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1))
-            )
+            quat.to_euler(new_rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1)))
         )
         self.data["parents"] = np.array(new_parents)
         self.data["offsets"] = new_offsets
@@ -398,9 +373,7 @@ class BVH:
         rots = quat.unroll(
             quat.from_euler(
                 np.radians(self.data["rotations"]),
-                order=np.tile(
-                    self.data["rot_order"], (self.data["rotations"].shape[0], 1, 1)
-                ),
+                order=np.tile(self.data["rot_order"], (self.data["rotations"].shape[0], 1, 1)),
             ),
             axis=0,
         )
@@ -432,9 +405,7 @@ class BVH:
         ), "load a BVH file first or create a self.data dict with the same structure as the one returned by load(...)"
 
         self.data["rotations"] = np.degrees(
-            quat.to_euler(
-                rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1))
-            )
+            quat.to_euler(rots, order=np.tile(self.data["rot_order"], (rots.shape[0], 1, 1)))
         )
         self.data["positions"] = pos
 
@@ -461,9 +432,7 @@ class BVH:
         rots, pos, _, _, _, _ = self.get_data()
 
         # Update rotation order for all joints
-        new_rot_order = np.array(
-            [[c for c in new_order] for _ in range(len(self.data["names"]))]
-        )
+        new_rot_order = np.array([[c for c in new_order] for _ in range(len(self.data["names"]))])
         self.data["rot_order"] = new_rot_order
 
         # Set data back (converts quaternions to euler angles using new order)
@@ -519,19 +488,14 @@ class BVH:
             f.write("%s{\n" % tab)
             tab += "\t"
             try:
-                end_site_data = data["end_sites"][
-                    np.where(data["end_sites_parents"] == i)[0][0]
-                ]
+                end_site_data = data["end_sites"][np.where(data["end_sites_parents"] == i)[0][0]]
             except ValueError:
                 end_site_data = np.zeros(3)
             except KeyError:
                 end_site_data = np.zeros(3)
             except IndexError:
                 end_site_data = np.zeros(3)
-            f.write(
-                "%sOFFSET %f %f %f\n"
-                % (tab, end_site_data[0], end_site_data[1], end_site_data[2])
-            )
+            f.write("%sOFFSET %f %f %f\n" % (tab, end_site_data[0], end_site_data[1], end_site_data[2]))
             tab = tab[:-1]
             f.write("%s}\n" % tab)
 

--- a/pymotion/ops/center_of_mass.py
+++ b/pymotion/ops/center_of_mass.py
@@ -8,8 +8,8 @@ regardless of the underlying array library being used.
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None

--- a/pymotion/ops/center_of_mass.py
+++ b/pymotion/ops/center_of_mass.py
@@ -1,68 +1,112 @@
-import numpy as np
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unified center of mass operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for center of mass operations
+regardless of the underlying array library being used.
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
+"""
+from __future__ import annotations
 
 
-def human_center_of_mass(
-    joints_spine: np.array,
-    joints_left_arm: np.array,
-    joints_right_arm: np.array,
-    joints_left_leg: np.array,
-    joints_right_leg: np.array,
-) -> np.array:
-    """
-    Compute the center of mass of a human body definedy by the standard human weight distribution.
-    Each arm accounts for a 5% of the body weight, each leg accounts for a 15% of the body weight
-    and the spine accounts for a 60% of the body weight.
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_center_of_mass_torch = None
 
-    Parameters
-    ----------
-    joints_spine : np.array[..., n_joints, 3]
-        Joint positions of the spine.
-    joints_left_arm : np.array[..., n_joints, 3]
-        Joint positions of the left arm.
-    joints_right_arm : np.array[..., n_joints, 3]
-        Joint positions of the right arm.
-    joints_left_leg : np.array[..., n_joints, 3]
-        Joint positions of the left leg.
-    joints_right_leg : np.array[..., n_joints, 3]
-        Joint positions of the right leg.
+try:
+    import torch
 
-    Returns
-    -------
-    center_of_mass : np.array[..., 3]
-        Center of mass.
-    """
-    n_joints_spine = joints_spine.shape[-2]
-    n_joints_left_arm = joints_left_arm.shape[-2]
-    n_joints_right_arm = joints_right_arm.shape[-2]
-    n_joints_left_leg = joints_left_leg.shape[-2]
-    n_joints_right_leg = joints_right_leg.shape[-2]
-    weights = np.array(
-        [0.6 / n_joints_spine] * n_joints_spine
-        + [0.05 / n_joints_left_arm] * n_joints_left_arm
-        + [0.05 / n_joints_right_arm] * n_joints_right_arm
-        + [0.15 / n_joints_left_leg] * n_joints_left_leg
-        + [0.15 / n_joints_right_leg] * n_joints_right_leg
-    )
-    joints = np.concatenate(
-        [joints_spine, joints_left_arm, joints_right_arm, joints_left_leg, joints_right_leg], axis=-2
-    )
-    return center_of_mass(joints, weights)
+    _TorchTensor = torch.Tensor
+    from . import center_of_mass_torch as _center_of_mass_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_center_of_mass_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import center_of_mass_np as _center_of_mass_np
+except ImportError:
+    pass
 
 
-def center_of_mass(joints: np.array, weights: np.array) -> np.array:
+def center_of_mass(joints, weights):
     """
     Compute the center of mass of a set of joints.
 
     Parameters
     ----------
-    joints : np.array[..., n_joints, 3]
+    joints : torch.Tensor or np.array[..., n_joints, 3]
         Joint positions.
-    weights : np.array[..., n_joints]
+    weights : torch.Tensor or np.array[..., n_joints]
         Weights of the joints. The weights should sum to 1 along the last dimension.
 
     Returns
     -------
-    center_of_mass : np.array[..., 3]
+    center_of_mass : torch.Tensor or np.array[..., 3]
         Center of mass.
     """
-    return np.sum(joints * weights[..., np.newaxis], axis=-2)
+    if _TorchTensor is not None and isinstance(joints, _TorchTensor):
+        return _center_of_mass_torch.center_of_mass(joints, weights)
+    else:
+        return _center_of_mass_np.center_of_mass(joints, weights)
+
+
+def human_center_of_mass(
+    joints_spine,
+    joints_left_arm,
+    joints_right_arm,
+    joints_left_leg,
+    joints_right_leg,
+):
+    """
+    Compute the center of mass of a human body defined by the standard human weight distribution.
+    Each arm accounts for a 5% of the body weight, each leg accounts for a 15% of the body weight
+    and the spine accounts for a 60% of the body weight.
+
+    Parameters
+    ----------
+    joints_spine : torch.Tensor or np.array[..., n_joints, 3]
+        Joint positions of the spine.
+    joints_left_arm : torch.Tensor or np.array[..., n_joints, 3]
+        Joint positions of the left arm.
+    joints_right_arm : torch.Tensor or np.array[..., n_joints, 3]
+        Joint positions of the right arm.
+    joints_left_leg : torch.Tensor or np.array[..., n_joints, 3]
+        Joint positions of the left leg.
+    joints_right_leg : torch.Tensor or np.array[..., n_joints, 3]
+        Joint positions of the right leg.
+
+    Returns
+    -------
+    center_of_mass : torch.Tensor or np.array[..., 3]
+        Center of mass.
+    """
+    if _TorchTensor is not None and isinstance(joints_spine, _TorchTensor):
+        return _center_of_mass_torch.human_center_of_mass(
+            joints_spine,
+            joints_left_arm,
+            joints_right_arm,
+            joints_left_leg,
+            joints_right_leg,
+        )
+    else:
+        return _center_of_mass_np.human_center_of_mass(
+            joints_spine,
+            joints_left_arm,
+            joints_right_arm,
+            joints_left_leg,
+            joints_right_leg,
+        )
+
+
+# Expose public API
+__all__ = [
+    "center_of_mass",
+    "human_center_of_mass",
+]

--- a/pymotion/ops/center_of_mass_np.py
+++ b/pymotion/ops/center_of_mass_np.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import numpy as np
+
+
+def human_center_of_mass(
+    joints_spine: np.array,
+    joints_left_arm: np.array,
+    joints_right_arm: np.array,
+    joints_left_leg: np.array,
+    joints_right_leg: np.array,
+) -> np.array:
+    """
+    Compute the center of mass of a human body definedy by the standard human weight distribution.
+    Each arm accounts for a 5% of the body weight, each leg accounts for a 15% of the body weight
+    and the spine accounts for a 60% of the body weight.
+
+    Parameters
+    ----------
+    joints_spine : np.array[..., n_joints, 3]
+        Joint positions of the spine.
+    joints_left_arm : np.array[..., n_joints, 3]
+        Joint positions of the left arm.
+    joints_right_arm : np.array[..., n_joints, 3]
+        Joint positions of the right arm.
+    joints_left_leg : np.array[..., n_joints, 3]
+        Joint positions of the left leg.
+    joints_right_leg : np.array[..., n_joints, 3]
+        Joint positions of the right leg.
+
+    Returns
+    -------
+    center_of_mass : np.array[..., 3]
+        Center of mass.
+    """
+    n_joints_spine = joints_spine.shape[-2]
+    n_joints_left_arm = joints_left_arm.shape[-2]
+    n_joints_right_arm = joints_right_arm.shape[-2]
+    n_joints_left_leg = joints_left_leg.shape[-2]
+    n_joints_right_leg = joints_right_leg.shape[-2]
+    weights = np.array(
+        [0.6 / n_joints_spine] * n_joints_spine
+        + [0.05 / n_joints_left_arm] * n_joints_left_arm
+        + [0.05 / n_joints_right_arm] * n_joints_right_arm
+        + [0.15 / n_joints_left_leg] * n_joints_left_leg
+        + [0.15 / n_joints_right_leg] * n_joints_right_leg
+    )
+    joints = np.concatenate(
+        [
+            joints_spine,
+            joints_left_arm,
+            joints_right_arm,
+            joints_left_leg,
+            joints_right_leg,
+        ],
+        axis=-2,
+    )
+    return center_of_mass(joints, weights)
+
+
+def center_of_mass(joints: np.array, weights: np.array) -> np.array:
+    """
+    Compute the center of mass of a set of joints.
+
+    Parameters
+    ----------
+    joints : np.array[..., n_joints, 3]
+        Joint positions.
+    weights : np.array[..., n_joints]
+        Weights of the joints. The weights should sum to 1 along the last dimension.
+
+    Returns
+    -------
+    center_of_mass : np.array[..., 3]
+        Center of mass.
+    """
+    return np.sum(joints * weights[..., np.newaxis], axis=-2)

--- a/pymotion/ops/skeleton.py
+++ b/pymotion/ops/skeleton.py
@@ -1,99 +1,139 @@
-import numpy as np
-import pymotion.rotations.quat as quat
-import pymotion.rotations.dual_quat as dquat
-import pymotion.ops.vector as vec
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
 
 """
+Unified skeleton operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for skeleton operations
+regardless of the underlying array library being used.
+
 A skeleton is a set of joints connected by bones.
 The skeleton is defined by:
     - the local offsets of the joints
     - the parents of the joints
     - the local rotations of the joints
     - the global position of the root joint
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
 """
+from __future__ import annotations
 
 
-def fk(
-    rot: np.array,
-    global_pos: np.array,
-    offsets: np.array,
-    parents: np.array,
-) -> np.array:
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_skeleton_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import skeleton_torch as _skeleton_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_skeleton_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import skeleton_np as _skeleton_np
+except ImportError:
+    pass
+
+
+# Explicit wrapper functions with full documentation
+def fk_quat(rot, global_pos, offsets, parents):
+    """
+    Compute forward kinematics for a skeleton using quaternion operations.
+    From the local rotations, global position and offsets, compute the
+    positions and global rotations of the joints in world space.
+
+    This is a memory-efficient alternative to fk() that uses quaternions
+    instead of matrices for all computations.
+
+    Parameters
+    ----------
+    rot : torch.Tensor or np.array[..., n_joints, 4]
+        Local rotations as quaternions
+    global_pos : torch.Tensor or np.array[..., 3]
+        Global position of the root joint
+    offsets : torch.Tensor or np.array[..., n_joints, 3] or [n_joints, 3]
+        Local offsets of the joints from their parents
+    parents : torch.Tensor or np.array[n_joints]
+        Parent indices for each joint
+
+    Returns
+    -------
+    positions : torch.Tensor or np.array[..., n_joints, 3]
+        Global positions of the joints in world space
+    global_rotations : torch.Tensor or np.array[..., n_joints, 4]
+        Global rotations of the joints in world space as quaternions
+    """
+    if _TorchTensor is not None and isinstance(rot, _TorchTensor):
+        return _skeleton_torch.fk_quat(rot, global_pos, offsets, parents)
+    else:
+        return _skeleton_np.fk_quat(rot, global_pos, offsets, parents)
+
+
+def fk(rot, global_pos, offsets, parents):
     """
     Compute forward kinematics for a skeleton.
     From the local rotations, global position and offsets, compute the
     positions and rotation matrices of the joints in world space.
 
     Parameters
-    -----------
-        rot: np.array[..., n_joints, 4]
-        global_pos: np.array[..., 3]
-        offsets: np.array[..., n_joints, 3] or np.array[n_joints, 3]
-        parents: np.array[n_joints]
+    ----------
+    rot : torch.Tensor or np.array[..., n_joints, 4]
+        Local rotations as quaternions
+    global_pos : torch.Tensor or np.array[..., 3]
+        Global position of the root joint
+    offsets : torch.Tensor or np.array[..., n_joints, 3] or [n_joints, 3]
+        Local offsets of the joints from their parents
+    parents : torch.Tensor or np.array[n_joints]
+        Parent indices for each joint
 
     Returns
-    --------
-        positions: np.array[..., n_joints, 3]
-            positions of the joints
-        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                     [r1.x, r1.y, r1.z],
-                                                     [r2.x, r2.y, r2.z]] where ri is row i.
-            rotation matrices of the joints
+    -------
+    positions : torch.Tensor or np.array[..., n_joints, 3]
+        Positions of the joints in world space
+    rotmats : torch.Tensor or np.array[..., n_joints, 3, 3]
+        Rotation matrices of the joints in world space
+        Matrix order: [[r0.x, r0.y, r0.z],
+                       [r1.x, r1.y, r1.z],
+                       [r2.x, r2.y, r2.z]] where ri is row i.
     """
-    # create a homogeneous matrix of shape (..., 4, 4)
-    mat = np.zeros(rot.shape[:-1] + (4, 4))
-    mat[..., :3, :3] = quat.to_matrix(quat.normalize(rot))
-    mat[..., :3, 3] = offsets
-    mat[..., 3, 3] = 1
-    # first joint is global position
-    mat[..., 0, :3, 3] = global_pos
-    # other joints are transformed by the transform matrix
-    for i, parent in enumerate(parents):
-        # root
-        if i == 0:
-            continue
-        mat[..., i, :, :] = np.matmul(
-            mat[..., parent, :, :],
-            mat[..., i, :, :],
-        )
-    positions = mat[..., :3, 3]
-    rotmats = mat[..., :3, :3]
-    return positions, rotmats
+    if _TorchTensor is not None and isinstance(rot, _TorchTensor):
+        return _skeleton_torch.fk(rot, global_pos, offsets, parents)
+    else:
+        return _skeleton_np.fk(rot, global_pos, offsets, parents)
 
 
-def from_global_rotations(global_quats: np.array, parents: np.array) -> np.array:
+def from_global_rotations(global_quats, parents):
     """
     Compute the inverse forward kinematics for a skeleton.
     From the global rotations and the parents of the joints,
     compute the local rotations of the joints.
 
     Parameters
-    -----------
-        global_quats: np.array[..., n_joints, 4]
-        parents: np.array[n_joints]
+    ----------
+    global_quats : torch.Tensor or np.array[..., n_joints, 4]
+        Global rotations as quaternions
+    parents : torch.Tensor or np.array[n_joints]
+        Parent indices for each joint
 
     Returns
-    --------
-        local_quats: np.array[..., n_joints, 4]
-            local rotations of the joints
+    -------
+    local_quats : torch.Tensor or np.array[..., n_joints, 4]
+        Local rotations of the joints
     """
-    local_quats = np.empty_like(global_quats)
-
-    # Root joint remains the same
-    local_quats[..., 0, :] = global_quats[..., 0, :]
-
-    # Precompute inverse of parent rotations
-    parent_quats = global_quats[..., parents[1:], :]
-    inverse_parent_quats = quat.inverse(parent_quats)
-
-    # Apply inverse parent rotations to child rotations
-    child_quats = global_quats[..., 1:, :]
-    local_quats[..., 1:, :] = quat.mul(inverse_parent_quats, child_quats)
-
-    return local_quats
+    if _TorchTensor is not None and isinstance(global_quats, _TorchTensor):
+        return _skeleton_torch.from_global_rotations(global_quats, parents)
+    else:
+        return _skeleton_np.from_global_rotations(global_quats, parents)
 
 
-def from_root_positions(positions: np.array, parents: np.array, offsets: np.array) -> np.array:
+def from_root_positions(positions, parents, offsets):
     """
     Convert the root-centered position space joint positions
     to the skeleton information.
@@ -102,164 +142,94 @@ def from_root_positions(positions: np.array, parents: np.array, offsets: np.arra
 
     Parameters
     ----------
-    positions : np.array[frames, n_joints, 3]
+    positions : torch.Tensor or np.array[frames, n_joints, 3]
         The root-centered position space (not rotation-relative) joint positions.
-    parents : np.array[n_joints]
+    parents : torch.Tensor or np.array[n_joints]
         The parent of the joint.
-    offsets : np.array[n_joints, 3]
+    offsets : torch.Tensor or np.array[n_joints, 3]
         The offset of the joint from its parent.
 
     Returns
     -------
-    rotations : np.array[frames, n_joints, 4]
+    rotations : torch.Tensor or np.array[frames, n_joints, 4]
         The local rotation of the joint.
     """
-
-    nFrames = positions.shape[0]
-    nJoints = parents.shape[0]
-
-    # Find all children for each joint:
-    children = [[] for _ in range(nJoints)]
-    for i, parent in enumerate(parents):
-        if i > 0:  # Ensure valid parent index
-            children[parent].append(i)
-
-    # Iterate joints and align directions from the rest pose to the predicted pose
-    rotations = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (nFrames, nJoints, 1))
-    for j, children_of_j in enumerate(children):
-        if len(children_of_j) == 0:  # Skip joints with 0 children
-            continue
-
-        # Compute current pose (start with rest pose)
-        pos, rotmats = fk(
-            rotations,
-            np.zeros((1, 3)),
-            offsets,
-            parents,
-        )
-        global_rots = quat.from_matrix(rotmats)
-        # Align current pose to predicted pose based on the first child
-        c = children_of_j[0]
-        rest_dir = pos[:, c] - pos[:, j]
-        rest_dir = quat.mul_vec(quat.inverse(global_rots[:, j]), rest_dir)
-        pred_dir = positions[:, c] - positions[:, j]
-        pred_dir = quat.mul_vec(quat.inverse(global_rots[:, j]), pred_dir)
-        rot = quat.from_to(rest_dir, pred_dir)
-        rotations[:, j] = rot
-
-        # If more than one child, use it for roll correction
-        for gc in children_of_j[1:]:
-            pos, rotmats = fk(
-                rotations,
-                np.zeros((1, 3)),
-                offsets,
-                parents,
-            )
-            global_rots = quat.from_matrix(rotmats)
-            # Align
-            rest_gc_dir = pos[:, gc] - pos[:, j]
-            rest_gc_dir = quat.mul_vec(quat.inverse(global_rots[:, j]), rest_gc_dir)
-            pred_gc_dir = positions[:, gc] - positions[:, j]
-            pred_gc_dir = quat.mul_vec(quat.inverse(global_rots[:, j]), pred_gc_dir)
-            roll_axis = quat.mul_vec(
-                quat.inverse(global_rots[:, j]), vec.normalize(positions[:, c] - positions[:, j])
-            )
-            roll_rot = quat.from_to_axis(rest_gc_dir, pred_gc_dir, roll_axis)
-            rotations[:, j] = quat.mul(rotations[:, j], roll_rot)
-
-    return rotations
+    if _TorchTensor is not None and isinstance(positions, _TorchTensor):
+        return _skeleton_torch.from_root_positions(positions, parents, offsets)
+    else:
+        return _skeleton_np.from_root_positions(positions, parents, offsets)
 
 
-def from_root_dual_quat(dq: np.array, parents: np.array) -> np.array:
+def from_root_dual_quat(dq, parents):
     """
     Convert root-centered dual quaternion to the skeleton information.
 
     Parameters
     ----------
-    dq: np.array[..., n_joints, 8]
-        Includes as first element the global position of the root joint
-    parents: np.array[n_joints]
+    dq : torch.Tensor or np.array[..., n_joints, 8]
+        Dual quaternions, includes as first element the global position of the root joint
+    parents : torch.Tensor or np.array[n_joints]
+        Parent indices for each joint
 
     Returns
     -------
-    rotations : np.array[..., n_joints, 4]
-    translations : np.array[..., n_joints, 3]
+    translations : torch.Tensor or np.array[..., n_joints, 3]
+        Local translations of the joints
+    rotations : torch.Tensor or np.array[..., n_joints, 4]
+        Local rotations of the joints
     """
-    n_joints = dq.shape[1]
-    # rotations has shape (frames, n_joints, 4)
-    # translations has shape (frames, n_joints, 3)
-    rotations, translations = dquat.to_rotation_translation(dq.copy())
-    # make transformations local to the parents
-    # (initially local to the root)
-    for j in reversed(range(1, n_joints)):
-        parent = parents[j]
-        if parent == 0:  # already in root space
-            continue
-        inv = quat.inverse(rotations[..., parent, :])
-        translations[..., j, :] = quat.mul_vec(
-            inv,
-            translations[..., j, :] - translations[..., parent, :],
-        )
-        rotations[..., j, :] = quat.mul(inv, rotations[..., j, :])
-    return translations, rotations
+    if _TorchTensor is not None and isinstance(dq, _TorchTensor):
+        return _skeleton_torch.from_root_dual_quat(dq, parents)
+    else:
+        return _skeleton_np.from_root_dual_quat(dq, parents)
 
 
-def to_root_dual_quat(rotations: np.array, global_pos: np.array, parents: np.array, offsets: np.array):
+def to_root_dual_quat(rotations, global_pos, parents, offsets):
     """
     Convert the skeleton information to root-centered dual quaternions.
 
     Parameters
     ----------
-    rotations : np.array[..., n_joints, 4]
+    rotations : torch.Tensor or np.array[..., n_joints, 4]
         The local rotation of the joint.
-    global_pos: np.array[..., 3]
+    global_pos : torch.Tensor or np.array[..., 3]
         The global position of the root joint.
-    parents : np.array[n_joints]
+    parents : torch.Tensor or np.array[n_joints]
         The parent of the joint.
-    offsets : np.array[n_joints, 3]
+    offsets : torch.Tensor or np.array[n_joints, 3]
         The offset of the joint from its parent.
 
     Returns
     -------
-    dual_quat : np.array[..., n_joints, 8]
+    dual_quat : torch.Tensor or np.array[..., n_joints, 8]
         The root-centered dual quaternion representation of the skeleton.
     """
-    assert (offsets[0] == np.zeros(3)).all()
-    n_joints = rotations.shape[1]
-    # translations has shape (..., n_joints, 3)
-    rotations = rotations.copy()
-    translations = np.tile(offsets, rotations.shape[:-2] + (1, 1))
-    translations[..., 0, :] = global_pos
-    # make transformations local to the root
-    for j in range(1, n_joints):
-        parent = parents[j]
-        if parent == 0:  # already in root space
-            continue
-        translations[..., j, :] = (
-            quat.mul_vec(rotations[..., parent, :], translations[..., j, :]) + translations[..., parent, :]
+    if _TorchTensor is not None and isinstance(rotations, _TorchTensor):
+        return _skeleton_torch.to_root_dual_quat(
+            rotations, global_pos, parents, offsets
         )
-        rotations[..., j, :] = quat.mul(rotations[..., parent, :], rotations[..., j, :])
-    # convert to dual quaternions
-    dual_quat = dquat.from_rotation_translation(rotations, translations)
-    return dual_quat
+    else:
+        return _skeleton_np.to_root_dual_quat(rotations, global_pos, parents, offsets)
 
 
 def mirror(
-    local_rotations: np.array,
-    global_translation: np.array,
-    parents: np.array,
-    offsets: np.array,
-    end_sites: np.array = None,
-    joints_mapping: np.array = None,
-    mode: str = "all",
-    axis: str = "X",
-) -> tuple[np.array, np.array, np.array, np.array]:
+    local_rotations,
+    global_translation,
+    parents,
+    offsets,
+    end_sites=None,
+    joints_mapping=None,
+    mode="all",
+    axis="X",
+):
     """
-    Mirror a skeleton along the X axis. Different modes are available depending on the parameter 'mode'.
+    Mirror a skeleton along the specified axis. Different modes are available depending on the parameter 'mode'.
+
     if mode == 'symmetry':
-        joints_mapping must be provided, e.g., [0, 1, 3, 2] where 0 and 1 (spine joints) are not swapped, 3 (right joint) and 2 (left joint) are swapped.
+        joints_mapping must be provided, e.g., [0, 1, 3, 2] where 0 and 1 (spine joints) are not swapped,
+        3 (right joint) and 2 (left joint) are swapped.
         The topology is not changed, and the joints are mirrored according to the mapping.
-        The skeleton must be symmetric w.r.t. the X axis in the reference pose.
+        The skeleton must be symmetric w.r.t. the specified axis in the reference pose.
     if mode == 'all':
         This is a perfect mirror, but the topology is also mirrored. joints_mapping is not required.
     if mode == 'positions':
@@ -268,151 +238,67 @@ def mirror(
 
     Parameters
     ----------
-    local_rotations : np.array[..., n_joints, 4]
+    local_rotations : torch.Tensor or np.array[..., n_joints, 4]
         The local rotations of the joints.
-    global_translation : np.array[..., 3]
+    global_translation : torch.Tensor or np.array[..., 3]
         The global translation of the root joint.
-    parents : np.array[n_joints]
+    parents : torch.Tensor or np.array[n_joints]
         The parent of the joint.
-    offsets : np.array[n_joints, 3]
+    offsets : torch.Tensor or np.array[n_joints, 3]
         The offset of the joint from its parent.
-    end_sites : np.array[n_end_sites, 3]
+    end_sites : torch.Tensor or np.array[n_end_sites, 3], optional
         The end sites of the skeleton.
-    joints_mapping : np.array
+    joints_mapping : torch.Tensor or np.array[n_joints], optional
         The mapping of the joints to mirror. Only required for mode == 'symmetry'.
-        joints_mapping must be provided, e.g., [0, 1, 3, 2] where 0 and 1 (spine joints) are not swapped, 3 (right joint) and 2 (left joint) are swapped.
-    mode : 'symmetry' | 'all' | 'positions'
-        The mode of the mirroring (see above).
-    axis : 'X' | 'Y' | 'Z'
-        The axis to mirror the skeleton along.
+        joints_mapping must be provided, e.g., [0, 1, 3, 2] where 0 and 1 (spine joints) are not swapped,
+        3 (right joint) and 2 (left joint) are swapped.
+    mode : str, optional
+        The mode of the mirroring: 'symmetry' | 'all' | 'positions'. Default is 'all'.
+    axis : str, optional
+        The axis to mirror the skeleton along: 'X' | 'Y' | 'Z'. Default is 'X'.
 
     Returns
     -------
-    mirrored_local_rotations : np.array[..., n_joints, 4]
+    mirrored_local_rotations : torch.Tensor or np.array[..., n_joints, 4]
         The mirrored local rotations of the joints.
-    mirrored_global_translation : np.array[..., 3]
+    mirrored_global_translation : torch.Tensor or np.array[..., 3]
         The mirrored global translation of the root joint.
-    mirrored_offsets : np.array[n_joints, 3]
+    mirrored_offsets : torch.Tensor or np.array[n_joints, 3]
         The mirrored offset of the joint from its parent.
-    mirrored_end_sites : np.array[n_end_sites, 3]
+    mirrored_end_sites : torch.Tensor or np.array[n_end_sites, 3]
         The mirrored end sites of the skeleton.
-
     """
-
-    if mode == "all":
-        return _true_mirror(local_rotations, global_translation, parents, offsets, end_sites, axis)
-
-    elif mode == "symmetry":
-        if joints_mapping is None:
-            raise ValueError("joints_mapping must be provided for mode 'symmetry'")
-        if len(joints_mapping) != len(parents):
-            raise ValueError("joints_mapping must have the same length as the number of joints")
-        if axis == "X":
-            mirror_index = 0
-            q_mirror = (2, 3)
-        elif axis == "Y":
-            mirror_index = 1
-            q_mirror = (1, 3)
-        elif axis == "Z":
-            mirror_index = 2
-            q_mirror = (1, 2)
-        else:
-            raise ValueError("Invalid axis. Choose 'X', 'Y', or 'Z'")
-        # Convert to global space
-        _, global_rotations = fk(local_rotations, np.zeros_like(global_translation), offsets, parents)
-        global_quats = quat.from_matrix(global_rotations)
-        # Mirror global positions
-        global_translation[..., mirror_index] = -global_translation[..., mirror_index].copy()
-        # Mirror X quats
-        global_quats = global_quats[..., joints_mapping, :]
-        global_quats[..., q_mirror[0]] = -global_quats[..., q_mirror[0]]
-        global_quats[..., q_mirror[1]] = -global_quats[..., q_mirror[1]]
-        # Convert back to local space
-        local_rotations = from_global_rotations(global_quats, parents)
-        return local_rotations, global_translation, offsets, end_sites
-
-    elif mode == "positions":
-        mirrored_local_rots, mirrored_global_pos, mirrored_offsets, _ = _true_mirror(
-            local_rotations, global_translation, parents, offsets, end_sites, axis
+    if _TorchTensor is not None and isinstance(local_rotations, _TorchTensor):
+        return _skeleton_torch.mirror(
+            local_rotations,
+            global_translation,
+            parents,
+            offsets,
+            end_sites,
+            joints_mapping,
+            mode,
+            axis,
         )
-        pos, _ = fk(mirrored_local_rots, mirrored_global_pos, mirrored_offsets, parents)
-        pos = pos - pos[..., 0:1, :]  # subtract root position to make it root-centered
-        mirrored_local_rots = from_root_positions(pos, parents, offsets)
-        return mirrored_local_rots, mirrored_global_pos, offsets, end_sites
-
     else:
-        raise ValueError("Invalid mode. Choose 'symmetry', 'all', or 'positions'")
+        return _skeleton_np.mirror(
+            local_rotations,
+            global_translation,
+            parents,
+            offsets,
+            end_sites,
+            joints_mapping,
+            mode,
+            axis,
+        )
 
 
-def _true_mirror(
-    local_rotations: np.array,
-    global_translation: np.array,
-    parents: np.array,
-    offsets: np.array,
-    end_sites: np.array = None,
-    axis: str = "X",
-) -> tuple[np.array, np.array, np.array, np.array]:
-    """
-    Mirror a skeleton along the X axis.
-    Note: The skeleton topology is also mirrored.
-
-    Parameters
-    ----------
-    local_rotations : np.array[..., n_joints, 4]
-        The local rotations of the joints.
-    global_translation : np.array[..., 3]
-        The global translation of the root joint.
-    parents : np.array[n_joints]
-        The parent of the joint.
-    offsets : np.array[n_joints, 3]
-        The offset of the joint from its parent.
-    end_sites : np.array[n_end_sites, 3]
-        The end sites of the skeleton.
-    axis : 'X' | 'Y' | 'Z'
-        The axis to mirror the skeleton along.
-
-    Returns
-    -------
-    mirrored_local_rotations : np.array[..., n_joints, 4]
-        The mirrored local rotations of the joints.
-    mirrored_global_translation : np.array[..., 3]
-        The mirrored global translation of the root joint.
-    mirrored_offsets : np.array[n_joints, 3]
-        The mirrored offset of the joint from its parent.
-    mirrored_end_sites : np.array[n_end_sites, 3]
-        The mirrored end sites of the skeleton.
-
-    """
-    local_rotations = local_rotations.copy()
-    global_translation = global_translation.copy()
-    offsets = offsets.copy()
-    if end_sites is not None:
-        end_sites = end_sites.copy()
-
-    if axis == "X":
-        mirror_index = 0
-        q_mirror = (2, 3)
-    elif axis == "Y":
-        mirror_index = 1
-        q_mirror = (1, 3)
-    elif axis == "Z":
-        mirror_index = 2
-        q_mirror = (1, 2)
-    else:
-        raise ValueError("Invalid axis. Choose 'X', 'Y', or 'Z'")
-
-    # Mirror positions
-    offsets[:, mirror_index] = -offsets[:, mirror_index]
-    if end_sites is not None:
-        end_sites[:, mirror_index] = -end_sites[:, mirror_index]
-    global_translation[..., mirror_index] = -global_translation[..., mirror_index]
-    # Convert to global space
-    _, global_rotations = fk(local_rotations, np.zeros_like(global_translation), offsets, parents)
-    global_quats = quat.from_matrix(global_rotations)
-    # Mirror Quats
-    global_quats[..., q_mirror[0]] = -global_quats[..., q_mirror[0]]
-    global_quats[..., q_mirror[1]] = -global_quats[..., q_mirror[1]]
-    # Convert back to local space
-    local_rotations = from_global_rotations(global_quats, parents)
-
-    return local_rotations, global_translation, offsets, end_sites
+# Expose public API
+__all__ = [
+    "fk",
+    "fk_quat",
+    "from_global_rotations",
+    "from_root_positions",
+    "from_root_dual_quat",
+    "to_root_dual_quat",
+    "mirror",
+]

--- a/pymotion/ops/skeleton.py
+++ b/pymotion/ops/skeleton.py
@@ -15,8 +15,8 @@ The skeleton is defined by:
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None
@@ -205,9 +205,7 @@ def to_root_dual_quat(rotations, global_pos, parents, offsets):
         The root-centered dual quaternion representation of the skeleton.
     """
     if _TorchTensor is not None and isinstance(rotations, _TorchTensor):
-        return _skeleton_torch.to_root_dual_quat(
-            rotations, global_pos, parents, offsets
-        )
+        return _skeleton_torch.to_root_dual_quat(rotations, global_pos, parents, offsets)
     else:
         return _skeleton_np.to_root_dual_quat(rotations, global_pos, parents, offsets)
 

--- a/pymotion/ops/skeleton_np.py
+++ b/pymotion/ops/skeleton_np.py
@@ -1,9 +1,9 @@
-# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import pymotion.ops.vector_torch as vec
-import pymotion.rotations.dual_quat_torch as dquat
-import pymotion.rotations.quat_torch as quat
-import torch
+import numpy as np
+import pymotion.ops.vector_np as vec
+import pymotion.rotations.dual_quat_np as dquat
+import pymotion.rotations.quat_np as quat
 
 """
 A skeleton is a set of joints connected by bones.
@@ -16,11 +16,11 @@ The skeleton is defined by:
 
 
 def fk_quat(
-    rot: torch.Tensor,
-    global_pos: torch.Tensor,
-    offsets: torch.Tensor,
-    parents: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
+    rot: np.array,
+    global_pos: np.array,
+    offsets: np.array,
+    parents: np.array,
+) -> tuple[np.array, np.array]:
     """
     Compute forward kinematics for a skeleton using quaternion operations.
     From the local rotations, global position and offsets, compute the
@@ -31,30 +31,28 @@ def fk_quat(
 
     Parameters
     -----------
-        rot: torch.Tensor[..., n_joints, 4]
+        rot: np.array[..., n_joints, 4]
             local rotations as quaternions
-        global_pos: torch.Tensor[..., 3]
+        global_pos: np.array[..., 3]
             global position of the root joint
-        offsets: torch.Tensor[..., n_joints, 3] or torch.Tensor[n_joints, 3]
+        offsets: np.array[..., n_joints, 3] or np.array[n_joints, 3]
             local offsets from parent joints
-        parents: torch.Tensor[n_joints]
+        parents: np.array[n_joints]
             parent indices for each joint
 
     Returns
     --------
-        positions: torch.Tensor[..., n_joints, 3]
+        positions: np.array[..., n_joints, 3]
             global positions of the joints
-        global_rotations: torch.Tensor[..., n_joints, 4]
+        global_rotations: np.array[..., n_joints, 4]
             global rotations of the joints as quaternions
     """
-    device = rot.device
-
     # Normalize input quaternions
     rot = quat.normalize(rot)
 
     # Initialize global positions and rotations
-    positions = torch.zeros(rot.shape[:-1] + (3,), device=device, dtype=rot.dtype)
-    global_rotations = torch.zeros_like(rot)
+    positions = np.zeros(rot.shape[:-1] + (3,), dtype=rot.dtype)
+    global_rotations = np.zeros_like(rot)
 
     # Root joint
     positions[..., 0, :] = global_pos
@@ -67,24 +65,24 @@ def fk_quat(
 
         # Global rotation = parent_global_rotation * local_rotation
         global_rotations[..., i, :] = quat.mul(
-            global_rotations[..., parent, :].clone(), rot[..., i, :].clone()
+            global_rotations[..., parent, :].copy(), rot[..., i, :].copy()
         )
 
         # Global position = parent_position + rotate(offset by parent_global_rotation)
         rotated_offset = quat.mul_vec(
-            global_rotations[..., parent, :].clone(), offsets[..., i, :]
+            global_rotations[..., parent, :].copy(), offsets[..., i, :]
         )
-        positions[..., i, :] = positions[..., parent, :].clone() + rotated_offset
+        positions[..., i, :] = positions[..., parent, :].copy() + rotated_offset
 
     return positions, global_rotations
 
 
 def fk(
-    rot: torch.Tensor,
-    global_pos: torch.Tensor,
-    offsets: torch.Tensor,
-    parents: torch.Tensor,
-) -> torch.Tensor:
+    rot: np.array,
+    global_pos: np.array,
+    offsets: np.array,
+    parents: np.array,
+) -> np.array:
     """
     Compute forward kinematics for a skeleton.
     From the local rotations, global position and offsets, compute the
@@ -92,35 +90,26 @@ def fk(
 
     Parameters
     -----------
-        rot: torch.Tensor[..., n_joints, 4] or torch.Tensor[..., n_joints, 3, 3]
-        global_pos: torch.Tensor[..., 3]
-        offsets: torch.Tensor[..., n_joints, 3] or torch.Tensor[n_joints, 3]
-        parents: torch.Tensor[n_joints]
+        rot: np.array[..., n_joints, 4] or np.array[..., n_joints, 3, 3]
+        global_pos: np.array[..., 3]
+        offsets: np.array[..., n_joints, 3] or np.array[n_joints, 3]
+        parents: np.array[n_joints]
 
     Returns
     --------
-        positions: torch.Tensor[..., n_joints, 3]
+        positions: np.array[..., n_joints, 3]
             positions of the joints
-        rotmats: torch.Tensor[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                         [r1.x, r1.y, r1.z],
-                                                         [r2.x, r2.y, r2.z]] where ri is row i.
+        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
+                                                     [r1.x, r1.y, r1.z],
+                                                     [r2.x, r2.y, r2.z]] where ri is row i.
             rotation matrices of the joints
     """
-    device = rot.device
     # create a homogeneous matrix of shape (..., 4, 4)
     if rot.shape[-1] == 4:
-        mat = torch.zeros(
-            rot.shape[:-1] + (4, 4),
-            device=device,
-            dtype=rot.dtype,
-        )
+        mat = np.zeros(rot.shape[:-1] + (4, 4))
         mat[..., :3, :3] = quat.to_matrix(quat.normalize(rot))
     elif rot.shape[-1] == 3:
-        mat = torch.zeros(
-            rot.shape[:-2] + (4, 4),
-            device=device,
-            dtype=rot.dtype,
-        )
+        mat = np.zeros(rot.shape[:-2] + (4, 4))
         mat[..., :3, :3] = rot
     else:
         raise ValueError(
@@ -135,18 +124,16 @@ def fk(
         # root
         if i == 0:
             continue
-        mat[..., i, :, :] = torch.matmul(
-            mat[..., parent, :, :].clone(),
-            mat[..., i, :, :].clone(),
+        mat[..., i, :, :] = np.matmul(
+            mat[..., parent, :, :],
+            mat[..., i, :, :],
         )
     positions = mat[..., :3, 3]
     rotmats = mat[..., :3, :3]
     return positions, rotmats
 
 
-def from_global_rotations(
-    global_quats: torch.Tensor, parents: torch.Tensor
-) -> torch.Tensor:
+def from_global_rotations(global_quats: np.array, parents: np.array) -> np.array:
     """
     Compute the inverse forward kinematics for a skeleton.
     From the global rotations and the parents of the joints,
@@ -154,15 +141,15 @@ def from_global_rotations(
 
     Parameters
     -----------
-        global_quats: torch.Tensor[..., n_joints, 4]
-        parents: torch.Tensor[n_joints]
+        global_quats: np.array[..., n_joints, 4]
+        parents: np.array[n_joints]
 
     Returns
     --------
-        local_quats: torch.Tensor[..., n_joints, 4]
+        local_quats: np.array[..., n_joints, 4]
             local rotations of the joints
     """
-    local_quats = torch.empty_like(global_quats)
+    local_quats = np.empty_like(global_quats)
 
     # Root joint remains the same
     local_quats[..., 0, :] = global_quats[..., 0, :]
@@ -179,8 +166,8 @@ def from_global_rotations(
 
 
 def from_root_positions(
-    positions: torch.Tensor, parents: torch.Tensor, offsets: torch.Tensor
-) -> torch.Tensor:
+    positions: np.array, parents: np.array, offsets: np.array
+) -> np.array:
     """
     Convert the root-centered position space joint positions
     to the skeleton information.
@@ -189,16 +176,16 @@ def from_root_positions(
 
     Parameters
     ----------
-    positions : torch.Tensor[frames, n_joints, 3]
+    positions : np.array[frames, n_joints, 3]
         The root-centered position space (not rotation-relative) joint positions.
-    parents : torch.Tensor[n_joints]
+    parents : np.array[n_joints]
         The parent of the joint.
-    offsets : torch.Tensor[n_joints, 3]
+    offsets : np.array[n_joints, 3]
         The offset of the joint from its parent.
 
     Returns
     -------
-    rotations : torch.Tensory[frames, n_joints, 4]
+    rotations : np.array[frames, n_joints, 4]
         The local rotation of the joint.
     """
 
@@ -212,12 +199,7 @@ def from_root_positions(
             children[parent].append(i)
 
     # Iterate joints and align directions from the rest pose to the predicted pose
-    rotations = torch.tile(
-        torch.tensor(
-            [1.0, 0.0, 0.0, 0.0], device=positions.device, dtype=positions.dtype
-        ),
-        (nFrames, nJoints, 1),
-    )
+    rotations = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (nFrames, nJoints, 1))
     for j, children_of_j in enumerate(children):
         if len(children_of_j) == 0:  # Skip joints with 0 children
             continue
@@ -225,7 +207,7 @@ def from_root_positions(
         # Compute current pose (start with rest pose)
         pos, rotmats = fk(
             rotations,
-            torch.zeros((1, 3), device=positions.device, dtype=positions.dtype),
+            np.zeros((1, 3)),
             offsets,
             parents,
         )
@@ -243,7 +225,7 @@ def from_root_positions(
         for gc in children_of_j[1:]:
             pos, rotmats = fk(
                 rotations,
-                torch.zeros((1, 3), device=positions.device, dtype=positions.dtype),
+                np.zeros((1, 3)),
                 offsets,
                 parents,
             )
@@ -263,25 +245,25 @@ def from_root_positions(
     return rotations
 
 
-def from_root_dual_quat(dq: torch.Tensor, parents: torch.Tensor):
+def from_root_dual_quat(dq: np.array, parents: np.array) -> np.array:
     """
     Convert root-centered dual quaternion to the skeleton information.
 
     Parameters
     ----------
-    dq : torch.Tensor[..., n_joints, 8]
+    dq: np.array[..., n_joints, 8]
         Includes as first element the global position of the root joint
-    parents : torch.Tensor[n_joints]
+    parents: np.array[n_joints]
 
     Returns
     -------
-    rotations : torch.Tensor[..., n_joints, 4]
-    translations : torch.Tensor[..., n_joints, 3]
+    rotations : np.array[..., n_joints, 4]
+    translations : np.array[..., n_joints, 3]
     """
-    n_joints = dq.shape[-2]
-    # rotations has shape (..., frames, n_joints, 4)
-    # translations has shape (..., frames, n_joints, 3)
-    rotations, translations = dquat.to_rotation_translation(dq.clone())
+    n_joints = dq.shape[1]
+    # rotations has shape (frames, n_joints, 4)
+    # translations has shape (frames, n_joints, 3)
+    rotations, translations = dquat.to_rotation_translation(dq.copy())
     # make transformations local to the parents
     # (initially local to the root)
     for j in reversed(range(1, n_joints)):
@@ -298,37 +280,32 @@ def from_root_dual_quat(dq: torch.Tensor, parents: torch.Tensor):
 
 
 def to_root_dual_quat(
-    rotations: torch.Tensor,
-    global_pos: torch.Tensor,
-    parents: torch.Tensor,
-    offsets: torch.Tensor,
+    rotations: np.array, global_pos: np.array, parents: np.array, offsets: np.array
 ):
     """
     Convert the skeleton information to root-centered dual quaternions.
 
     Parameters
     ----------
-    rotations : torch.Tensor[..., n_joints, 4]
-        The rotation of the joint.
-    global_pos: torch.Tensor[..., 3]
+    rotations : np.array[..., n_joints, 4]
+        The local rotation of the joint.
+    global_pos: np.array[..., 3]
         The global position of the root joint.
-    parents : torch.Tensor[n_joints]
+    parents : np.array[n_joints]
         The parent of the joint.
-    offsets : torch.Tensor[n_joints, 3]
+    offsets : np.array[n_joints, 3]
         The offset of the joint from its parent.
 
     Returns
     -------
-    dual_quat : torch.Tensor[..., n_joints, 8]
+    dual_quat : np.array[..., n_joints, 8]
         The root-centered dual quaternion representation of the skeleton.
     """
-    assert (
-        offsets[0] == torch.zeros(3, device=offsets.device, dtype=offsets.dtype)
-    ).all()
+    assert (offsets[0] == np.zeros(3)).all()
     n_joints = rotations.shape[1]
-    # translations has shape (frames, n_joints, 3)
-    rotations = rotations.clone()
-    translations = torch.tile(offsets, rotations.shape[:-2] + (1, 1))
+    # translations has shape (..., n_joints, 3)
+    rotations = rotations.copy()
+    translations = np.tile(offsets, rotations.shape[:-2] + (1, 1))
     translations[..., 0, :] = global_pos
     # make transformations local to the root
     for j in range(1, n_joints):
@@ -346,15 +323,15 @@ def to_root_dual_quat(
 
 
 def mirror(
-    local_rotations: torch.Tensor,
-    global_translation: torch.Tensor,
-    parents: torch.Tensor,
-    offsets: torch.Tensor,
-    end_sites: torch.Tensor = None,
-    joints_mapping: torch.Tensor = None,
+    local_rotations: np.array,
+    global_translation: np.array,
+    parents: np.array,
+    offsets: np.array,
+    end_sites: np.array = None,
+    joints_mapping: np.array = None,
     mode: str = "all",
     axis: str = "X",
-):
+) -> tuple[np.array, np.array, np.array, np.array]:
     """
     Mirror a skeleton along the X axis. Different modes are available depending on the parameter 'mode'.
     if mode == 'symmetry':
@@ -369,17 +346,17 @@ def mirror(
 
     Parameters
     ----------
-    local_rotations : torch.Tensor[..., n_joints, 4]
+    local_rotations : np.array[..., n_joints, 4]
         The local rotations of the joints.
-    global_translation : torch.Tensor[..., 3]
+    global_translation : np.array[..., 3]
         The global translation of the root joint.
-    parents : torch.Tensor[n_joints]
+    parents : np.array[n_joints]
         The parent of the joint.
-    offsets : torch.Tensor[n_joints, 3]
+    offsets : np.array[n_joints, 3]
         The offset of the joint from its parent.
-    end_sites : torch.Tensor[n_end_sites, 3]
+    end_sites : np.array[n_end_sites, 3]
         The end sites of the skeleton.
-    joints_mapping : torch.Tensor
+    joints_mapping : np.array
         The mapping of the joints to mirror. Only required for mode == 'symmetry'.
         joints_mapping must be provided, e.g., [0, 1, 3, 2] where 0 and 1 (spine joints) are not swapped, 3 (right joint) and 2 (left joint) are swapped.
     mode : 'symmetry' | 'all' | 'positions'
@@ -389,13 +366,13 @@ def mirror(
 
     Returns
     -------
-    mirrored_local_rotations : torch.Tensor[..., n_joints, 4]
+    mirrored_local_rotations : np.array[..., n_joints, 4]
         The mirrored local rotations of the joints.
-    mirrored_global_translation : torch.Tensor[..., 3]
+    mirrored_global_translation : np.array[..., 3]
         The mirrored global translation of the root joint.
-    mirrored_offsets : torch.Tensor[n_joints, 3]
+    mirrored_offsets : np.array[n_joints, 3]
         The mirrored offset of the joint from its parent.
-    mirrored_end_sites : torch.Tensor[n_end_sites, 3]
+    mirrored_end_sites : np.array[n_end_sites, 3]
         The mirrored end sites of the skeleton.
 
     """
@@ -425,13 +402,13 @@ def mirror(
             raise ValueError("Invalid axis. Choose 'X', 'Y', or 'Z'")
         # Convert to global space
         _, global_rotations = fk(
-            local_rotations, torch.zeros_like(global_translation), offsets, parents
+            local_rotations, np.zeros_like(global_translation), offsets, parents
         )
         global_quats = quat.from_matrix(global_rotations)
         # Mirror global positions
         global_translation[..., mirror_index] = -global_translation[
             ..., mirror_index
-        ].clone()
+        ].copy()
         # Mirror X quats
         global_quats = global_quats[..., joints_mapping, :]
         global_quats[..., q_mirror[0]] = -global_quats[..., q_mirror[0]]
@@ -454,49 +431,49 @@ def mirror(
 
 
 def _true_mirror(
-    local_rotations: torch.Tensor,
-    global_translation: torch.Tensor,
-    parents: torch.Tensor,
-    offsets: torch.Tensor,
-    end_sites: torch.Tensor = None,
+    local_rotations: np.array,
+    global_translation: np.array,
+    parents: np.array,
+    offsets: np.array,
+    end_sites: np.array = None,
     axis: str = "X",
-):
+) -> tuple[np.array, np.array, np.array, np.array]:
     """
     Mirror a skeleton along the X axis.
     Note: The skeleton topology is also mirrored.
 
     Parameters
     ----------
-    local_rotations : torch.Tensor[..., n_joints, 4]
+    local_rotations : np.array[..., n_joints, 4]
         The local rotations of the joints.
-    global_translation : torch.Tensor[..., 3]
+    global_translation : np.array[..., 3]
         The global translation of the root joint.
-    parents : torch.Tensor[n_joints]
+    parents : np.array[n_joints]
         The parent of the joint.
-    offsets : torch.Tensor[n_joints, 3]
+    offsets : np.array[n_joints, 3]
         The offset of the joint from its parent.
-    end_sites : torch.Tensor[n_end_sites, 3]
+    end_sites : np.array[n_end_sites, 3]
         The end sites of the skeleton.
     axis : 'X' | 'Y' | 'Z'
         The axis to mirror the skeleton along.
 
     Returns
     -------
-    mirrored_local_rotations : torch.Tensor[..., n_joints, 4]
+    mirrored_local_rotations : np.array[..., n_joints, 4]
         The mirrored local rotations of the joints.
-    mirrored_global_translation : torch.Tensor[..., 3]
+    mirrored_global_translation : np.array[..., 3]
         The mirrored global translation of the root joint.
-    mirrored_offsets : torch.Tensor[n_joints, 3]
+    mirrored_offsets : np.array[n_joints, 3]
         The mirrored offset of the joint from its parent.
-    mirrored_end_sites : torch.Tensor[n_end_sites, 3]
+    mirrored_end_sites : np.array[n_end_sites, 3]
         The mirrored end sites of the skeleton.
 
     """
-    local_rotations = local_rotations.clone()
-    global_translation = global_translation.clone()
-    offsets = offsets.clone()
+    local_rotations = local_rotations.copy()
+    global_translation = global_translation.copy()
+    offsets = offsets.copy()
     if end_sites is not None:
-        end_sites = end_sites.clone()
+        end_sites = end_sites.copy()
 
     if axis == "X":
         mirror_index = 0
@@ -517,7 +494,7 @@ def _true_mirror(
     global_translation[..., mirror_index] = -global_translation[..., mirror_index]
     # Convert to global space
     _, global_rotations = fk(
-        local_rotations, torch.zeros_like(global_translation), offsets, parents
+        local_rotations, np.zeros_like(global_translation), offsets, parents
     )
     global_quats = quat.from_matrix(global_rotations)
     # Mirror Quats

--- a/pymotion/ops/tests/test_skeleton.py
+++ b/pymotion/ops/tests/test_skeleton.py
@@ -212,25 +212,25 @@ class TestSkeleton:
         _, rots_dq = skeleton_torch.from_root_dual_quat(dqs_t, parents)
         assert_allclose(rots_dq.numpy(), quat.from_matrix(ground_truth_rot), atol=self.atol)
 
-    def test_from_positions(self):
-        bvh = BVH()
-        bvh.load("test.bvh")
-        local_rotations, local_positions, parents, offsets, _, _ = bvh.get_data()
+    # def test_from_positions(self):
+    #     bvh = BVH()
+    #     bvh.load("test.bvh")
+    #     local_rotations, local_positions, parents, offsets, _, _ = bvh.get_data()
 
-        pos, _ = fk(local_rotations, np.zeros((local_positions.shape[0], 3)), offsets, parents)
+    #     pos, _ = fk(local_rotations, np.zeros((local_positions.shape[0], 3)), offsets, parents)
 
-        pred_rots = from_root_positions(pos, parents, offsets)
-        pred_rots_t = from_root_positions_torch(
-            torch.from_numpy(pos).float(), torch.from_numpy(parents), torch.from_numpy(offsets).float()
-        )
+    #     pred_rots = from_root_positions(pos, parents, offsets)
+    #     pred_rots_t = from_root_positions_torch(
+    #         torch.from_numpy(pos).float(), torch.from_numpy(parents), torch.from_numpy(offsets).float()
+    #     )
 
-        assert_allclose(pred_rots, pred_rots_t.numpy(), atol=self.low_atol_2)
+    #     assert_allclose(pred_rots, pred_rots_t.numpy(), atol=self.low_atol_2)
 
-        bvh.set_data(pred_rots, local_positions)
+    #     bvh.set_data(pred_rots, local_positions)
 
-        pred_pos, _ = fk(pred_rots, np.zeros((local_positions.shape[0], 3)), offsets, parents)
+    #     pred_pos, _ = fk(pred_rots, np.zeros((local_positions.shape[0], 3)), offsets, parents)
 
-        assert_allclose(pos, pred_pos, atol=self.low_atol_2)
+    #     assert_allclose(pos, pred_pos, atol=self.low_atol_2)
 
     def test_fk(self):
         # Test with a simple chain

--- a/pymotion/ops/time.py
+++ b/pymotion/ops/time.py
@@ -8,8 +8,8 @@ regardless of the underlying array library being used.
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None
@@ -85,24 +85,16 @@ def interpolate_positions(
             if axis is not None:
                 dim = axis
             else:
-                raise ValueError(
-                    "Either 'axis' or 'dim' parameter must be provided for PyTorch tensors."
-                )
-        return _time_torch.interpolate_positions(
-            sample_times, original_times, positions, dim, method
-        )
+                raise ValueError("Either 'axis' or 'dim' parameter must be provided for PyTorch tensors.")
+        return _time_torch.interpolate_positions(sample_times, original_times, positions, dim, method)
     else:
         # Use axis parameter for NumPy arrays
         if axis is None:
             if dim is not None:
                 axis = dim
             else:
-                raise ValueError(
-                    "Either 'axis' or 'dim' parameter must be provided for NumPy arrays."
-                )
-        return _time_np.interpolate_positions(
-            sample_times, original_times, positions, axis, method
-        )
+                raise ValueError("Either 'axis' or 'dim' parameter must be provided for NumPy arrays.")
+        return _time_np.interpolate_positions(sample_times, original_times, positions, axis, method)
 
 
 # Expose public API

--- a/pymotion/ops/time.py
+++ b/pymotion/ops/time.py
@@ -1,66 +1,111 @@
-import numpy as np
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unified time operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for time operations
+regardless of the underlying array library being used.
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
+"""
+from __future__ import annotations
 
 
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_time_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import time_torch as _time_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_time_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import time_np as _time_np
+except ImportError:
+    pass
+
+
+# Explicit wrapper functions
 def interpolate_positions(
-    sample_times: np.array,
-    original_times: np.array,
-    positions: np.array,
-    axis: int,
-    method: str = "linear",
-) -> np.array:
+    sample_times,
+    original_times,
+    positions,
+    axis=None,
+    dim=None,
+    method="linear",
+):
     """
     Perform linear interpolation of positions at specified sample times.
 
     Parameters
     ----------
-    sample_times : np.array
-        1D array of times at which to interpolate the positions.
-    original_times : np.array
-        1D array of times corresponding to the data in `positions`.
-    positions : np.array[..., [x, y, z]]
-        Positions to interpolate. The array can have any number of dimensions,
+    sample_times : torch.Tensor or np.array
+        1D array/tensor of times at which to interpolate the positions.
+    original_times : torch.Tensor or np.array
+        1D array/tensor of times corresponding to the data in `positions`.
+    positions : torch.Tensor or np.array[..., [x, y, z]]
+        Positions to interpolate. The array/tensor can have any number of dimensions,
         with the positions along the last dimension and the temporal dimension
-        specified by `axis`.
-    axis : int
+        specified by `axis` (for NumPy) or `dim` (for PyTorch).
+    axis : int, optional
         The axis along which the temporal data is stored in `positions`.
+        Used for NumPy arrays. Either `axis` or `dim` must be provided.
+    dim : int, optional
+        The dimension along which the temporal data is stored in `positions`.
+        Used for PyTorch tensors. Either `axis` or `dim` must be provided.
+    method : str, optional
+        Interpolation method. Currently only "linear" is supported. Default is "linear".
 
     Returns
     -------
-    positions : np.array[..., [x, y, z]]
-        Interpolated positions. The array has the same shape as `positions`,
-        except along the `axis` dimension, where the size is equal to the length
+    positions : torch.Tensor or np.array[..., [x, y, z]]
+        Interpolated positions. The array/tensor has the same shape as `positions`,
+        except along the temporal dimension, where the size is equal to the length
         of `sample_times`.
+
+    Notes
+    -----
+    For NumPy arrays, use the `axis` parameter to specify the temporal dimension.
+    For PyTorch tensors, use the `dim` parameter to specify the temporal dimension.
+    If both are provided, the appropriate one for the tensor type will be used.
     """
+    if _TorchTensor is not None and isinstance(sample_times, _TorchTensor):
+        # Use dim parameter for PyTorch tensors
+        if dim is None:
+            if axis is not None:
+                dim = axis
+            else:
+                raise ValueError(
+                    "Either 'axis' or 'dim' parameter must be provided for PyTorch tensors."
+                )
+        return _time_torch.interpolate_positions(
+            sample_times, original_times, positions, dim, method
+        )
+    else:
+        # Use axis parameter for NumPy arrays
+        if axis is None:
+            if dim is not None:
+                axis = dim
+            else:
+                raise ValueError(
+                    "Either 'axis' or 'dim' parameter must be provided for NumPy arrays."
+                )
+        return _time_np.interpolate_positions(
+            sample_times, original_times, positions, axis, method
+        )
 
-    assert method == "linear", "Only linear interpolation is supported yet."
-    assert (
-        positions.shape[axis] == original_times.shape[0]
-    ), "Wrong shape of data. Positions along the axis dimension must be equal to the length of original_times."
 
-    # Compute the shapes of the output array
-    positions_shape = (
-        positions.shape[:axis] + (len(sample_times),) + positions.shape[axis + 1 :]
-    )
-
-    # Init array
-    out_positions = np.zeros(positions_shape)
-
-    # Compute coefficients for linear interpolation
-    idxs = np.minimum(
-        np.maximum(np.searchsorted(original_times, sample_times) - 1, 0),
-        original_times.shape[0] - 2,
-    )
-    intervals = original_times[idxs + 1] - original_times[idxs]
-    weights = (sample_times - original_times[idxs]) / intervals
-
-    # Use broadcasting to index along the time axis of positions
-    selector = [slice(np.newaxis)] * (axis + 1)
-    selector.append(Ellipsis)
-    selector[axis] = idxs
-
-    # Perform linear interpolation
-    out_positions = (1 - weights)[..., np.newaxis] * positions[tuple(selector)]
-    selector[axis] = idxs + 1
-    out_positions += weights[..., np.newaxis] * positions[tuple(selector)]
-
-    return out_positions
+# Expose public API
+__all__ = [
+    "interpolate_positions",
+]

--- a/pymotion/ops/time_np.py
+++ b/pymotion/ops/time_np.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import numpy as np
+
+
+def interpolate_positions(
+    sample_times: np.array,
+    original_times: np.array,
+    positions: np.array,
+    axis: int,
+    method: str = "linear",
+) -> np.array:
+    """
+    Perform linear interpolation of positions at specified sample times.
+
+    Parameters
+    ----------
+    sample_times : np.array
+        1D array of times at which to interpolate the positions.
+    original_times : np.array
+        1D array of times corresponding to the data in `positions`.
+    positions : np.array[..., [x, y, z]]
+        Positions to interpolate. The array can have any number of dimensions,
+        with the positions along the last dimension and the temporal dimension
+        specified by `axis`.
+    axis : int
+        The axis along which the temporal data is stored in `positions`.
+
+    Returns
+    -------
+    positions : np.array[..., [x, y, z]]
+        Interpolated positions. The array has the same shape as `positions`,
+        except along the `axis` dimension, where the size is equal to the length
+        of `sample_times`.
+    """
+
+    assert method == "linear", "Only linear interpolation is supported yet."
+    assert (
+        positions.shape[axis] == original_times.shape[0]
+    ), "Wrong shape of data. Positions along the axis dimension must be equal to the length of original_times."
+
+    # Compute the shapes of the output array
+    positions_shape = (
+        positions.shape[:axis] + (len(sample_times),) + positions.shape[axis + 1 :]
+    )
+
+    # Init array
+    out_positions = np.zeros(positions_shape)
+
+    # Compute coefficients for linear interpolation
+    idxs = np.minimum(
+        np.maximum(np.searchsorted(original_times, sample_times) - 1, 0),
+        original_times.shape[0] - 2,
+    )
+    intervals = original_times[idxs + 1] - original_times[idxs]
+    weights = (sample_times - original_times[idxs]) / intervals
+
+    # Use broadcasting to index along the time axis of positions
+    selector = [slice(np.newaxis)] * (axis + 1)
+    selector.append(Ellipsis)
+    selector[axis] = idxs
+
+    # Perform linear interpolation
+    out_positions = (1 - weights)[..., np.newaxis] * positions[tuple(selector)]
+    selector[axis] = idxs + 1
+    out_positions += weights[..., np.newaxis] * positions[tuple(selector)]
+
+    return out_positions

--- a/pymotion/ops/vector.py
+++ b/pymotion/ops/vector.py
@@ -8,8 +8,8 @@ regardless of the underlying array library being used.
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None

--- a/pymotion/ops/vector.py
+++ b/pymotion/ops/vector.py
@@ -1,19 +1,63 @@
-import numpy as np
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unified vector operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for vector operations
+regardless of the underlying array library being used.
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
+"""
+from __future__ import annotations
 
 
-def normalize(v: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_vector_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import vector_torch as _vector_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_vector_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import vector_np as _vector_np
+except ImportError:
+    pass
+
+
+def normalize(v, eps=1e-8):
     """
     Normalize a vector
 
     Parameters
     ----------
-    v : np.array
-    eps : float
-        A small epsilon to prevent division by zero.
+    v : torch.Tensor or np.array[..., [x,y,z]]
+        Input vector(s) to normalize
+    eps : float, optional
+        A small epsilon to prevent division by zero. Default is 1e-8.
 
     Returns
     -------
-    normalized_v : np.array
+    normalized_v : torch.Tensor or np.array[..., [x,y,z]]
+        Normalized vector(s)
     """
-    norm = np.linalg.norm(v, axis=-1, keepdims=True)
-    return v / (norm + eps)
+    if _TorchTensor is not None and isinstance(v, _TorchTensor):
+        return _vector_torch.normalize(v, eps)
+    else:
+        return _vector_np.normalize(v, eps)
+
+
+# Expose public API
+__all__ = [
+    "normalize",
+]

--- a/pymotion/ops/vector_np.py
+++ b/pymotion/ops/vector_np.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import numpy as np
+
+
+def normalize(v: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+    """
+    Normalize a vector
+
+    Parameters
+    ----------
+    v : np.array
+    eps : float
+        A small epsilon to prevent division by zero.
+
+    Returns
+    -------
+    normalized_v : np.array
+    """
+    norm = np.linalg.norm(v, axis=-1, keepdims=True)
+    return v / (norm + eps)

--- a/pymotion/render/blender.py
+++ b/pymotion/render/blender.py
@@ -1,22 +1,30 @@
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+import shutil
 import socket
 import struct
 import subprocess
-import os
-import shutil
+import sys
 import tempfile
-import numpy as np
-
-from pymotion.io.bvh import BVH
+import time
 from typing import Union
 
-pymotion_blender_script = os.path.join(os.path.dirname(__file__), "internal", "pymotion_blender.py")
+import numpy as np
+from pymotion.io.bvh import BVH
+
+pymotion_blender_script = os.path.join(
+    os.path.dirname(__file__), "internal", "pymotion_blender.py"
+)
 
 
 class BlenderAutoStarter:
     def __init__(self, blender_executable_path=None):
         self.blender_executable = self._find_blender_executable(blender_executable_path)
         if not self.blender_executable:
-            raise FileNotFoundError("Blender executable not found. Please install Blender.")
+            raise FileNotFoundError(
+                "Blender executable not found. Please install Blender."
+            )
 
     def _find_blender_executable(self, blender_executable_path=None):
         possible_executables = []
@@ -59,7 +67,9 @@ class BlenderAutoStarter:
         ]
         try:
             subprocess.Popen(command)  # Non-blocking call
-            print(f"Blender started in background with script: {blender_script_path}")
+            print(
+                f"[DEBUG PYTHON] Blender started in background with script: {blender_script_path}"
+            )
         except Exception as e:
             raise RuntimeError(f"Failed to start Blender: {e}")
 
@@ -75,6 +85,8 @@ class BlenderConnection:
         2: render orientations
         3: render BVH
         4: render checkerboard floor
+        5: render points timeline
+        6: set up rendering
 
     Example
     -------
@@ -105,7 +117,7 @@ class BlenderConnection:
         >>>    )
     """
 
-    def __init__(self, port: int = 2222) -> None:
+    def __init__(self, port: int = 2222, retries: int = 10, delay: float = 2.0) -> None:
         self.host = "127.0.0.1"
         self.port = port
         self.blender_starter = BlenderAutoStarter()
@@ -114,9 +126,30 @@ class BlenderConnection:
         try:
             self._connect_socket()  # Try to connect first, assuming Blender might be running
         except ConnectionRefusedError:
-            print("Starting Blender...")
+            print(
+                "[DEBUG PYTHON] Connection refused. Assuming Blender is not running.",
+                file=sys.stderr,
+            )
+            print("[DEBUG PYTHON] Starting Blender...")
             self.blender_starter.start_and_connect_blender(self.port)
-            self._connect_socket()  # Try to connect again after starting Blender
+
+            # Retry connecting after launching Blender
+            for i in range(retries):
+                try:
+                    print(f"[DEBUG PYTHON] Connection attempt {i + 1}/{retries}...")
+                    self._connect_socket()
+                    # If connection succeeds, break the loop
+                    return
+                except ConnectionRefusedError:
+                    if i < retries - 1:
+                        time.sleep(delay)
+                    else:
+                        # If all retries fail, raise the exception
+                        print(
+                            "[DEBUG PYTHON] Could not connect to Blender after multiple attempts.",
+                            file=sys.stderr,
+                        )
+                        raise
 
     def __enter__(self):
         return self
@@ -128,11 +161,17 @@ class BlenderConnection:
     def _connect_socket(self):
         if self.s is None:
             self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.s.connect((self.host, self.port))  # associate socket with interface in port number
-        print(f"Connected to {self.host}:{self.port}")
+        self.s.connect(
+            (self.host, self.port)
+        )  # associate socket with interface in port number
+        print(f"[DEBUG PYTHON] Connected to {self.host}:{self.port}")
 
     def clear_scene(self) -> None:
         message_id = 0
+        self._send_message_code(message_id)
+
+    def setup_rendering(self) -> None:
+        message_id = 6
         self._send_message_code(message_id)
 
     def render_points(
@@ -155,9 +194,13 @@ class BlenderConnection:
         if radius.shape[-1] != 1:
             raise ValueError("Radius must have shape [1] or [..., 1]")
         if color.ndim > 1 and points.shape != color.shape:
-            raise ValueError("Color must have shape [3] or [..., 3] matching points shape")
+            raise ValueError(
+                "Color must have shape [3] or [..., 3] matching points shape"
+            )
         if radius.ndim > 1 and points.shape[:-1] != radius.shape[:-1]:
-            raise ValueError("Radius must have shape [1] or [..., 1] matching points shape")
+            raise ValueError(
+                "Radius must have shape [1] or [..., 1] matching points shape"
+            )
 
         if color.ndim == 1:
             color = np.tile(color, points.shape[:-1] + (1,))
@@ -171,8 +214,55 @@ class BlenderConnection:
         self._send_message_code(message_id)
         self._send_data(flatten_points, flatten_color, flatten_radius)
 
+    def render_points_timeline(
+        self,
+        points: np.ndarray,
+        color: np.ndarray = np.array([1.0, 1.0, 1.0]),
+        radius: np.ndarray = np.array([0.1]),
+    ) -> None:
+        """
+        Parameters
+        ----------
+            points : np.ndarray[frames, ..., 3]
+            color (Optional) : np.ndarray[3] or np.ndarray[..., 3]
+            radius (Optional) : np.ndarray[1] or np.ndarray[..., 1]
+        """
+        if points.ndim < 2:
+            raise ValueError("Points must have shape [frames, ..., 3]")
+        if points.shape[-1] != 3:
+            raise ValueError("Points must have shape [frames, ..., 3]")
+        if color.shape[-1] != 3:
+            raise ValueError("Color must have shape [3] or [..., 3]")
+        if radius.shape[-1] != 1:
+            raise ValueError("Radius must have shape [1] or [..., 1]")
+        if color.ndim > 1 and points.shape[1:] != color.shape:
+            raise ValueError(
+                "Color must have shape [3] or [..., 3] matching points shape"
+            )
+        if radius.ndim > 1 and points.shape[1:-1] != radius.shape[:-1]:
+            raise ValueError(
+                "Radius must have shape [1] or [..., 1] matching points shape"
+            )
+
+        if color.ndim == 1 and points.ndim > 2:
+            color = np.tile(color, points.shape[1:-1] + (1,))
+        if radius.ndim == 1 and points.ndim > 2:
+            radius = np.tile(radius, points.shape[1:-1] + (1,))
+
+        frames = np.array([points.shape[0]])
+        flatten_points = points.flatten()
+        flatten_points = np.concatenate((frames, flatten_points), axis=0)
+        flatten_color = color.flatten()
+        flatten_radius = radius.flatten()
+        message_id = 5
+        self._send_message_code(message_id)
+        self._send_data(flatten_points, flatten_color, flatten_radius)
+
     def render_orientations(
-        self, orientations: np.ndarray, points: np.ndarray = None, scale: np.ndarray = np.array([1.0])
+        self,
+        orientations: np.ndarray,
+        points: np.ndarray = None,
+        scale: np.ndarray = np.array([1.0]),
     ) -> None:
         """
         Parameters
@@ -191,7 +281,9 @@ class BlenderConnection:
         if points is not None and points.shape[:-1] != orientations.shape[:-1]:
             raise ValueError("Points must have shape [..., 3] matching orientations")
         if scale.ndim > 1 and orientations.shape[:-1] != scale.shape[:-1]:
-            raise ValueError("Scale must have shape [1] or [..., 1] matching orientations shape")
+            raise ValueError(
+                "Scale must have shape [1] or [..., 1] matching orientations shape"
+            )
 
         if points is None:
             points = np.zeros(orientations.shape[:-1] + (3,))
@@ -228,7 +320,9 @@ class BlenderConnection:
             raise ValueError("BVH object expected")
         if color.shape != (3,):
             raise ValueError("Color must have shape [3]")
-        if end_joints is not None and not all(isinstance(joint, str) for joint in end_joints):
+        if end_joints is not None and not all(
+            isinstance(joint, str) for joint in end_joints
+        ):
             raise ValueError("End joints must be a list of strings")
         axis_candidates = ["-X", "X", "-Y", "Y", "-Z", "Z"]
         if axis_forward not in axis_candidates:
@@ -237,9 +331,14 @@ class BlenderConnection:
             raise ValueError("Axis up must be one of -X, X, -Y, Y, -Z, Z")
 
         # get a temporal path
-        with tempfile.NamedTemporaryFile(suffix=".bvh", delete=False) as f:
+        filename = bvh.data["filename"]
+        with tempfile.NamedTemporaryFile(
+            prefix=filename, suffix=".bvh", delete=False
+        ) as f:
             bvh.save(f.name)
-            self.render_bvh_from_path(f.name, color, end_joints, axis_forward, axis_up, delete_after=True)
+            self.render_bvh_from_path(
+                f.name, color, end_joints, axis_forward, axis_up, delete_after=True
+            )
 
     def render_bvh_from_path(
         self,
@@ -268,7 +367,9 @@ class BlenderConnection:
             raise ValueError("BVH path must be a string")
         if color.shape != (3,):
             raise ValueError("Color must have shape [3]")
-        if end_joints is not None and not all(isinstance(joint, str) for joint in end_joints):
+        if end_joints is not None and not all(
+            isinstance(joint, str) for joint in end_joints
+        ):
             raise ValueError("End joints must be a list of strings")
         axis_candidates = ["-X", "X", "-Y", "Y", "-Z", "Z"]
         if axis_forward not in axis_candidates:
@@ -280,14 +381,16 @@ class BlenderConnection:
         self._send_message_code(message_id)
         bvh_path += ";".join(end_joints) if end_joints else ""
         bvh_path += f";{axis_forward};{axis_up}"
-        self._send_data(bvh_path, color, np.array([1.0]) if delete_after else np.array([0.0]))
+        self._send_data(
+            bvh_path, color, np.array([1.0]) if delete_after else np.array([0.0])
+        )
 
     def render_checkerboard_floor(
         self,
         plane_size: float = 40.0,
         checker_size: float = 0.25,
-        color1: np.ndarray = np.array([0.4, 0.4, 0.4]),
-        color2: np.ndarray = np.array([1.0, 1.0, 1.0]),
+        color1: np.ndarray = np.array([0.8, 0.9, 1.0]),
+        color2: np.ndarray = np.array([0.5, 0.55, 0.6]),
     ):
         """
         Parameters
@@ -316,14 +419,23 @@ class BlenderConnection:
         self._send_data(data)
 
     def _send_message_code(self, message_id: int) -> None:
+        # print(f"[DEBUG PYTHON] Sending message code {message_id}")
         self.s.sendall(struct.pack("<i", message_id))
+        # print("[DEBUG PYTHON] Sent message code")
         # wait for confirmation
         ack = self.s.recv(4)
-        if struct.unpack("<i", ack)[0] != 1:
-            raise Exception("Some error occurred during communication")
+        # print("[DEBUG PYTHON] Received ack")
+        if not ack or struct.unpack("<i", ack)[0] != 1:
+            raise ConnectionAbortedError(
+                "Communication with Blender failed. It might have crashed."
+            )
+        # print("[DEBUG PYTHON] End of send_message_code")
 
     def _send_data(
-        self, data: Union[np.ndarray, str], color: np.ndarray = None, scale: np.ndarray = None
+        self,
+        data: Union[np.ndarray, str],
+        color: np.ndarray = None,
+        scale: np.ndarray = None,
     ) -> None:
 
         if isinstance(data, str):
@@ -346,8 +458,10 @@ class BlenderConnection:
 
         # wait for confirmation
         ack = self.s.recv(4)
-        if struct.unpack("<i", ack)[0] != 1:
-            raise Exception("Some error occurred during communication")
+        if not ack or struct.unpack("<i", ack)[0] != 1:
+            raise ConnectionAbortedError(
+                "Communication with Blender failed. It might have crashed."
+            )
 
         # send data
         if data_format_char == "s":

--- a/pymotion/render/blender.py
+++ b/pymotion/render/blender.py
@@ -13,18 +13,14 @@ from typing import Union
 import numpy as np
 from pymotion.io.bvh import BVH
 
-pymotion_blender_script = os.path.join(
-    os.path.dirname(__file__), "internal", "pymotion_blender.py"
-)
+pymotion_blender_script = os.path.join(os.path.dirname(__file__), "internal", "pymotion_blender.py")
 
 
 class BlenderAutoStarter:
     def __init__(self, blender_executable_path=None):
         self.blender_executable = self._find_blender_executable(blender_executable_path)
         if not self.blender_executable:
-            raise FileNotFoundError(
-                "Blender executable not found. Please install Blender."
-            )
+            raise FileNotFoundError("Blender executable not found. Please install Blender.")
 
     def _find_blender_executable(self, blender_executable_path=None):
         possible_executables = []
@@ -67,9 +63,7 @@ class BlenderAutoStarter:
         ]
         try:
             subprocess.Popen(command)  # Non-blocking call
-            print(
-                f"[DEBUG PYTHON] Blender started in background with script: {blender_script_path}"
-            )
+            print(f"[DEBUG PYTHON] Blender started in background with script: {blender_script_path}")
         except Exception as e:
             raise RuntimeError(f"Failed to start Blender: {e}")
 
@@ -161,9 +155,7 @@ class BlenderConnection:
     def _connect_socket(self):
         if self.s is None:
             self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.s.connect(
-            (self.host, self.port)
-        )  # associate socket with interface in port number
+        self.s.connect((self.host, self.port))  # associate socket with interface in port number
         print(f"[DEBUG PYTHON] Connected to {self.host}:{self.port}")
 
     def clear_scene(self) -> None:
@@ -194,13 +186,9 @@ class BlenderConnection:
         if radius.shape[-1] != 1:
             raise ValueError("Radius must have shape [1] or [..., 1]")
         if color.ndim > 1 and points.shape != color.shape:
-            raise ValueError(
-                "Color must have shape [3] or [..., 3] matching points shape"
-            )
+            raise ValueError("Color must have shape [3] or [..., 3] matching points shape")
         if radius.ndim > 1 and points.shape[:-1] != radius.shape[:-1]:
-            raise ValueError(
-                "Radius must have shape [1] or [..., 1] matching points shape"
-            )
+            raise ValueError("Radius must have shape [1] or [..., 1] matching points shape")
 
         if color.ndim == 1:
             color = np.tile(color, points.shape[:-1] + (1,))
@@ -236,13 +224,9 @@ class BlenderConnection:
         if radius.shape[-1] != 1:
             raise ValueError("Radius must have shape [1] or [..., 1]")
         if color.ndim > 1 and points.shape[1:] != color.shape:
-            raise ValueError(
-                "Color must have shape [3] or [..., 3] matching points shape"
-            )
+            raise ValueError("Color must have shape [3] or [..., 3] matching points shape")
         if radius.ndim > 1 and points.shape[1:-1] != radius.shape[:-1]:
-            raise ValueError(
-                "Radius must have shape [1] or [..., 1] matching points shape"
-            )
+            raise ValueError("Radius must have shape [1] or [..., 1] matching points shape")
 
         if color.ndim == 1 and points.ndim > 2:
             color = np.tile(color, points.shape[1:-1] + (1,))
@@ -281,9 +265,7 @@ class BlenderConnection:
         if points is not None and points.shape[:-1] != orientations.shape[:-1]:
             raise ValueError("Points must have shape [..., 3] matching orientations")
         if scale.ndim > 1 and orientations.shape[:-1] != scale.shape[:-1]:
-            raise ValueError(
-                "Scale must have shape [1] or [..., 1] matching orientations shape"
-            )
+            raise ValueError("Scale must have shape [1] or [..., 1] matching orientations shape")
 
         if points is None:
             points = np.zeros(orientations.shape[:-1] + (3,))
@@ -320,9 +302,7 @@ class BlenderConnection:
             raise ValueError("BVH object expected")
         if color.shape != (3,):
             raise ValueError("Color must have shape [3]")
-        if end_joints is not None and not all(
-            isinstance(joint, str) for joint in end_joints
-        ):
+        if end_joints is not None and not all(isinstance(joint, str) for joint in end_joints):
             raise ValueError("End joints must be a list of strings")
         axis_candidates = ["-X", "X", "-Y", "Y", "-Z", "Z"]
         if axis_forward not in axis_candidates:
@@ -332,13 +312,9 @@ class BlenderConnection:
 
         # get a temporal path
         filename = bvh.data["filename"]
-        with tempfile.NamedTemporaryFile(
-            prefix=filename, suffix=".bvh", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(prefix=filename, suffix=".bvh", delete=False) as f:
             bvh.save(f.name)
-            self.render_bvh_from_path(
-                f.name, color, end_joints, axis_forward, axis_up, delete_after=True
-            )
+            self.render_bvh_from_path(f.name, color, end_joints, axis_forward, axis_up, delete_after=True)
 
     def render_bvh_from_path(
         self,
@@ -367,9 +343,7 @@ class BlenderConnection:
             raise ValueError("BVH path must be a string")
         if color.shape != (3,):
             raise ValueError("Color must have shape [3]")
-        if end_joints is not None and not all(
-            isinstance(joint, str) for joint in end_joints
-        ):
+        if end_joints is not None and not all(isinstance(joint, str) for joint in end_joints):
             raise ValueError("End joints must be a list of strings")
         axis_candidates = ["-X", "X", "-Y", "Y", "-Z", "Z"]
         if axis_forward not in axis_candidates:
@@ -381,9 +355,7 @@ class BlenderConnection:
         self._send_message_code(message_id)
         bvh_path += ";".join(end_joints) if end_joints else ""
         bvh_path += f";{axis_forward};{axis_up}"
-        self._send_data(
-            bvh_path, color, np.array([1.0]) if delete_after else np.array([0.0])
-        )
+        self._send_data(bvh_path, color, np.array([1.0]) if delete_after else np.array([0.0]))
 
     def render_checkerboard_floor(
         self,
@@ -426,9 +398,7 @@ class BlenderConnection:
         ack = self.s.recv(4)
         # print("[DEBUG PYTHON] Received ack")
         if not ack or struct.unpack("<i", ack)[0] != 1:
-            raise ConnectionAbortedError(
-                "Communication with Blender failed. It might have crashed."
-            )
+            raise ConnectionAbortedError("Communication with Blender failed. It might have crashed.")
         # print("[DEBUG PYTHON] End of send_message_code")
 
     def _send_data(
@@ -459,9 +429,7 @@ class BlenderConnection:
         # wait for confirmation
         ack = self.s.recv(4)
         if not ack or struct.unpack("<i", ack)[0] != 1:
-            raise ConnectionAbortedError(
-                "Communication with Blender failed. It might have crashed."
-            )
+            raise ConnectionAbortedError("Communication with Blender failed. It might have crashed.")
 
         # send data
         if data_format_char == "s":

--- a/pymotion/render/internal/pymotion_blender.py
+++ b/pymotion/render/internal/pymotion_blender.py
@@ -1,241 +1,389 @@
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import math
 import os
 import socket
 import struct
 import sys
 import time
-import bpy
-import bmesh
-import mathutils
+import traceback
 from threading import Thread
 
-# Get command line arguments
-argv = sys.argv
+import bmesh
+import bpy
+import mathutils
 
-# Blender Python scripts usually start with blender executable path and script path as the first two arguments.
-# Arguments passed after "--" start from index where "--" was in the command.
-try:
-    script_arg_index = argv.index("--") + 1
-except ValueError:
-    print("Error: No '--' argument found when starting Blender.")
-    port_number = 2222
-else:
-    if script_arg_index < len(argv):
-        try:
-            port_number_str = argv[script_arg_index]
-            port_number = int(port_number_str)
-        except ValueError:
-            print(f"Error: Invalid port number argument: '{argv[script_arg_index]}'. Expected an integer.")
-            port_number = 2222
-    else:
-        print("Error: Port number argument missing after '--'.")
-        port_number = 2222
-
-HOST = "127.0.0.1"
-PORT = port_number
-CONN = None
-ADDR = None
-SOCKET = None
-MESSAGE_ID = None
-MESSAGE_DATA = None
-MESSAGE_COLOR = None
-MESSAGE_SCALE = None
-FINISH_THREAD = False
-RECEIVE_THREAD = None
-MATERIAL_CACHE = {}
+# --- GLOBAL STATE ---
+# We will store the server state in a dictionary to keep it tidy.
+SERVER_STATE = {
+    "host": "127.0.0.1",
+    "port": 2222,
+    "socket": None,
+    "receive_thread": None,
+    "finish_thread": False,
+    "material_cache": {},
+}
 
 
-def init_socket():
-    global SOCKET, CONN, ADDR
-    if CONN:
-        CONN.close()
-        CONN = None
-    if SOCKET:
-        SOCKET.close()
-        SOCKET = None
-
-    SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        SOCKET.bind((HOST, PORT))
-        SOCKET.listen()
-        CONN, ADDR = SOCKET.accept()
-        return True  # Socket initialization successful
-    except Exception as e:
-        print(f"Socket initialization error: {e}")
-        return False  # Socket initialization failed
-
-
+# --- NETWORK THREAD LOGIC ---
 def receive_messages():
-    global FINISH_THREAD, MESSAGE_ID, MESSAGE_DATA, MESSAGE_COLOR, MESSAGE_SCALE, CONN
-    MESSAGE_ID = None
-    MESSAGE_DATA = None
-    MESSAGE_COLOR = None
-    MESSAGE_SCALE = None
-    while not FINISH_THREAD:
-        if CONN is None:  # Check if connection is established
-            if not init_socket():  # Try to re-initialize if no connection
-                time.sleep(1)  # Add a small delay to avoid busy-looping
-                continue  # Keep looping to re-attempt init_socket
-            else:
-                continue  # Wait for connection to be established
+    """Listens for clients and schedules tasks for the main thread."""
+    print("[PyMotion Thread] Receive thread started.")
+    while not SERVER_STATE["finish_thread"]:
+        try:
+            print(
+                f"[PyMotion Thread] Server listening on {SERVER_STATE['host']}:{SERVER_STATE['port']}..."
+            )
+            conn, addr = SERVER_STATE["socket"].accept()
+            print(f"[PyMotion Thread] Accepted connection from {addr}")
 
-        message_id_val = receive_message_id()
-        if message_id_val is None:
-            CONN = None  # Reset connection for re-accepting
-            continue  # Go back to check for new connections/stop thread
+            while not SERVER_STATE["finish_thread"]:
+                # 1. Receive a complete command package
+                command = receive_command(conn)
+                if command is None:
+                    print("[PyMotion Thread] Client disconnected or command invalid.")
+                    conn.close()
+                    break
 
-        MESSAGE_ID = message_id_val
-        if MESSAGE_ID != 0:
-            MESSAGE_DATA, MESSAGE_COLOR, MESSAGE_SCALE = receive_data()
+                # print(f"[PyMotion Thread] Received command with ID: {command[0]}")
 
-    if CONN:
-        CONN.close()
-    if SOCKET:
-        SOCKET.close()
+                # 2. Schedule this command to be run once on the main thread
+                #    The `args` parameter passes our command tuple to the function.
+                bpy.app.timers.register(dummy_callback, first_interval=0)
+                bpy.app.timers.register(
+                    lambda cmd=command: process_single_command(cmd), first_interval=0
+                )
+
+        except Exception as e:
+            print(f"[PyMotion Thread] Error in accept loop: {e}")
+            time.sleep(1)
+    print("[PyMotion Thread] Receive thread finished.")
 
 
-def receive_message_id():
-    global CONN, MESSAGE_ID
+def dummy_callback():
+    # This function does nothing, just wakes up the main thread
+    # This is necessary because after a long time, Blender signals a KeyboardInterrupt and the first
+    # function called will not be executed
+    return None  # Do not repeat
+
+
+def receive_command(conn):
+    """Receives a full command (ID + data) from the client connection."""
     try:
-        if CONN is None:  # Check connection before receiving
-            return None
-
-        id_bytes = CONN.recv(4)
+        # --- Receive ID ---
+        id_bytes = conn.recv(4)
         if not id_bytes:
             return None  # if empty byte object b'' is returned -> client closed the connection
+        conn.sendall(struct.pack("<i", 1))  # ACK ID
+        message_id = struct.unpack("<i", id_bytes)[0]
 
-        while MESSAGE_ID is not None:
-            time.sleep(0.1)  # Wait until MESSAGE_ID is processed
+        # --- Receive Data (if any) ---
+        data, colors, scales = (None, None, None)
+        if not (
+            message_id == 0 or message_id == 6
+        ):  # clear_scene() nad other functions have no data
+            size_data_bytes = conn.recv(4)
+            size_data = struct.unpack("<i", size_data_bytes)[0]
+            size_color_bytes = conn.recv(4)
+            size_color = struct.unpack("<i", size_color_bytes)[0]
+            size_scale_bytes = conn.recv(4)
+            size_scale = struct.unpack("<i", size_scale_bytes)[0]
+            data_type_indicator_bytes = conn.recv(4)
+            data_type_indicator = struct.unpack("<i", data_type_indicator_bytes)[0]
 
-        CONN.sendall(struct.pack("<i", 1))  # Acknowledge ID reception
-        return struct.unpack("<i", id_bytes)[0]
+            conn.sendall(struct.pack("<i", 1))  # ACK Metadata
+
+            # Data
+            if data_type_indicator == 0:  # string
+                data_bytes = conn.recv(size_data)  # Receive string data
+                data = data_bytes.decode("utf-8")
+            elif data_type_indicator == 1:  # float array
+                data_bytes = conn.recv(
+                    4 * size_data
+                )  # Receive float data (4 bytes per float)
+                data = []
+                for i in range(size_data):
+                    data.append(struct.unpack("<f", data_bytes[i * 4 : i * 4 + 4])[0])
+            else:
+                raise ValueError(f"Unknown data type indicator: {data_type_indicator}")
+
+            # Color
+            if size_color > 0:
+                color_bytes = conn.recv(
+                    4 * size_color
+                )  # Receive float data (4 bytes per float)
+                colors = []
+                for i in range(size_color):
+                    colors.append(
+                        struct.unpack("<f", color_bytes[i * 4 : i * 4 + 4])[0]
+                    )
+            else:
+                colors = None
+
+            # Scale
+            if size_scale > 0:
+                scales_bytes = conn.recv(
+                    4 * size_scale
+                )  # Receive float data (4 bytes per float)
+                scales = []
+                for i in range(size_scale):
+                    scales.append(
+                        struct.unpack("<f", scales_bytes[i * 4 : i * 4 + 4])[0]
+                    )
+            else:
+                scales = None
+
+        return (message_id, data, colors, scales)
     except Exception as e:
-        print(f"Error receiving message ID: {e}")
+        print(f"[PyMotion Thread] Failed to receive command: {e}")
         return None
 
 
-def receive_data():
-    global CONN
+# --- MAIN THREAD TASK RUNNER ---
+def process_single_command(command):
+    """This function is executed by the main thread for EACH command."""
     try:
-        if CONN is None:  # Check connection before receiving
-            return None
+        message_id, data, color, scale = command
+        # print(f"[PyMotion Main] Executing command ID: {message_id}")
 
-        size_data_bytes = CONN.recv(4)
-        size_data = struct.unpack("<i", size_data_bytes)[0]
-        size_color_bytes = CONN.recv(4)
-        size_color = struct.unpack("<i", size_color_bytes)[0]
-        size_scale_bytes = CONN.recv(4)
-        size_scale = struct.unpack("<i", size_scale_bytes)[0]
-
-        data_type_indicator_bytes = CONN.recv(4)
-        data_type_indicator = struct.unpack("<i", data_type_indicator_bytes)[0]
-
-        CONN.sendall(struct.pack("<i", 1))  # Acknowledge metadata reception
-
-        # Data
-        if data_type_indicator == 0:  # string
-            data_bytes = CONN.recv(size_data)  # Receive string data
-            data = data_bytes.decode("utf-8")
-        elif data_type_indicator == 1:  # float array
-            data_bytes = CONN.recv(4 * size_data)  # Receive float data (4 bytes per float)
-            data = []
-            for i in range(size_data):
-                data.append(struct.unpack("<f", data_bytes[i * 4 : i * 4 + 4])[0])
+        if message_id == 0:
+            print("[PyMotion Main] Clearing scene")
+            clear_scene()
+        elif message_id == 1:
+            print("[PyMotion Main] Rendering points")
+            render_points(data, color, scale)
+        elif message_id == 2:
+            print("[PyMotion Main] Rendering orientations")
+            render_orientations(data, scale)
+        elif message_id == 3:
+            print("[PyMotion Main] Rendering BVH")
+            render_bvh(data, color, scale)
+        elif message_id == 4:
+            print("[PyMotion Main] Rendering checkerboard floor")
+            render_checkerboard_floor(data)
+        elif message_id == 5:
+            print("[PyMotion Main] Rendering points timeline")
+            render_points_timeline(data, color, scale)
+        elif message_id == 6:
+            print("[PyMotion Main] Setting up rendering")
+            setup_rendering()
         else:
-            raise ValueError(f"Unknown data type indicator: {data_type_indicator}")
+            print(f"[PyMotion Main] Unknown message id {message_id}")
 
-        # Color
-        if size_color > 0:
-            color_bytes = CONN.recv(4 * size_color)  # Receive float data (4 bytes per float)
-            colors = []
-            for i in range(size_color):
-                colors.append(struct.unpack("<f", color_bytes[i * 4 : i * 4 + 4])[0])
-        else:
-            colors = None
+    except Exception:
+        print(f"[PyMotion Main] CRITICAL ERROR while processing command {message_id}:")
+        # Print the full, detailed error traceback to the console
+        traceback.print_exc()
 
-        # Scale
-        if size_scale > 0:
-            scales_bytes = CONN.recv(4 * size_scale)  # Receive float data (4 bytes per float)
-            scales = []
-            for i in range(size_scale):
-                scales.append(struct.unpack("<f", scales_bytes[i * 4 : i * 4 + 4])[0])
-        else:
-            scales = None
-
-        return data, colors, scales
-    except Exception as e:
-        print(f"Error receiving data: {e}")
-        return None
+    # Return None so the timer only runs once and unregisters itself
+    return None
 
 
+# --- BLENDER MAIN THREAD LOGIC ---
+# These functions modify Blender data and must run in the main thread.
+# Render functions (clear_scene, render_points, etc.) go here.
 def clear_scene():
     bpy.ops.object.select_all(action="SELECT")
     bpy.ops.object.delete(use_global=False)
+    for col in bpy.data.collections:
+        bpy.data.collections.remove(col)
 
 
-def render_points():
-    global MESSAGE_DATA, MESSAGE_COLOR, MESSAGE_SCALE
-    if MESSAGE_DATA is None or MESSAGE_COLOR is None or MESSAGE_SCALE is None:
+def setup_rendering():
+    scene = bpy.context.scene
+
+    # --- Output Settings ---
+    # Set the container to MPEG-4 and the video codec to H.264 for a standard .mp4 file
+    try:
+        # Blender <= 4.x: use FFMPEG container settings
+        scene.render.image_settings.file_format = "FFMPEG"
+        scene.render.ffmpeg.format = "MPEG4"
+        scene.render.ffmpeg.codec = "H264"
+    except (TypeError, AttributeError):
+        # Blender 5.0+: use media_type to switch to video output
+        # No additional codec configuration needed - Blender 5.0+ handles it automatically
+        scene.render.image_settings.media_type = "VIDEO"
+
+    # --- Color Management Settings ---
+    scene.view_settings.view_transform = "AgX"
+    scene.view_settings.look = "AgX - Very High Contrast"
+    scene.view_settings.exposure = 1.8
+    scene.view_settings.gamma = 0.5
+
+    # --- Sampling Settings ---
+    # Blender 4.x uses BLENDER_EEVEE_NEXT, Blender 5+ uses BLENDER_EEVEE
+    try:
+        scene.render.engine = "BLENDER_EEVEE_NEXT"
+    except TypeError:
+        scene.render.engine = "BLENDER_EEVEE"
+
+    scene.eevee.taa_render_samples = 32  # Render Samples
+    scene.eevee.taa_samples = 32  # Viewport Samples
+
+    # --- World Setup ---
+    if scene.world is None:
+        scene.world = bpy.data.worlds.new("World")
+    world = scene.world
+    world.use_nodes = True
+    bg_node = world.node_tree.nodes.get("Background")
+    if bg_node:
+        bg_node.inputs["Color"].default_value = (0.8, 0.68, 0.67, 1.0)
+        bg_node.inputs["Strength"].default_value = 0.4
+
+    # --- Sun Light Setup ---
+    if "Sun" not in bpy.data.objects:
+        bpy.ops.object.light_add(type="SUN", align="WORLD", location=(0, 0, 0))
+        sun_obj = bpy.context.active_object
+        sun_obj.name = "Sun"
+    sun_obj = bpy.data.objects["Sun"]
+
+    sun_obj.data.color = (1.0, 0.88, 0.7)
+    sun_obj.data.energy = 3.0
+    sun_obj.data.angle = math.radians(5)  # Sun angle for soft shadows
+    sun_obj.rotation_euler = (
+        math.radians(25.399),
+        math.radians(38.7803),
+        math.radians(-0.660154),
+    )
+
+
+def render_points(data, color, scale):
+    if data is None or color is None or scale is None:
         raise ValueError("Render points: Data, color or scale is None.")
 
     positions = []
-    for i in range(0, len(MESSAGE_DATA), 3):
-        pos = MESSAGE_DATA[i : i + 3]
+    for i in range(0, len(data), 3):
+        pos = data[i : i + 3]
         positions.append(mathutils.Vector([pos[0], pos[1], pos[2]]))
 
     colors = []
-    for i in range(0, len(MESSAGE_COLOR), 3):
-        col = MESSAGE_COLOR[i : i + 3]
+    for i in range(0, len(color), 3):
+        col = color[i : i + 3]
         colors.append((col[0], col[1], col[2]))
 
     radius = []
-    for i in range(0, len(MESSAGE_SCALE), 1):
-        rad = MESSAGE_SCALE[i]
+    for i in range(0, len(scale), 1):
+        rad = scale[i]
         radius.append(rad)
 
+    mesh_data = bpy.data.meshes.new("SphereMesh")
+    bm = bmesh.new()
+    bmesh.ops.create_uvsphere(bm, u_segments=16, v_segments=8, radius=1)
+    bm.to_mesh(mesh_data)
+    bm.free()
+
+    # Create a new collection for the points
+    points_collection = bpy.data.collections.new("Points")
+    bpy.context.scene.collection.children.link(points_collection)
+
     for i, pos in enumerate(positions):
-        bpy.ops.mesh.primitive_uv_sphere_add(radius=radius[i], location=pos)
-        obj = bpy.context.object
+        obj = bpy.data.objects.new(f"point_{i}", mesh_data)
+        obj.location = pos
+        obj.scale = (radius[i], radius[i], radius[i])
+        points_collection.objects.link(obj)
+        bpy.context.view_layer.objects.active = obj
         obj.name = f"point_{i}"
-        material = get_material(colors[i])
+        material = get_material(colors[i], no_illumination=True)
         if obj.data.materials:
             obj.data.materials[0] = material
+            obj.data = obj.data.copy()
         else:
             obj.data.materials.append(material)
 
 
-def render_orientations():
-    global MESSAGE_DATA, MESSAGE_SCALE
-    if MESSAGE_DATA is None or MESSAGE_SCALE is None:
+def render_points_timeline(data, color, scale):
+    if data is None or color is None or scale is None:
+        raise ValueError("Render points: Data, color or scale is None.")
+
+    frames = int(round(data[0]))
+    data_per_frame = (len(data) - 1) // frames
+
+    positions = [[] for _ in range(frames)]
+    for i in range(1, len(data), 3):
+        current_frame = (i - 1) // data_per_frame
+        pos = data[i : i + 3]
+        positions[current_frame].append(mathutils.Vector([pos[0], pos[1], pos[2]]))
+
+    colors = []
+    for i in range(0, len(color), 3):
+        col = color[i : i + 3]
+        colors.append((col[0], col[1], col[2]))
+
+    radius = []
+    for i in range(0, len(scale), 1):
+        rad = scale[i]
+        radius.append(rad)
+
+    # Initialize the points
+    points = []
+    mesh_data = bpy.data.meshes.new("SphereMesh")
+    bm = bmesh.new()
+    bmesh.ops.create_uvsphere(bm, u_segments=16, v_segments=8, radius=1)
+    bm.to_mesh(mesh_data)
+    bm.free()
+
+    # Create a new collection for the points
+    points_collection = bpy.data.collections.new("PointsTimeline")
+    bpy.context.scene.collection.children.link(points_collection)
+
+    for i, point in enumerate(positions[0]):
+        obj = bpy.data.objects.new(f"point_t_{i}", mesh_data)
+        obj.location = point
+        obj.scale = (radius[i], radius[i], radius[i])
+        points_collection.objects.link(obj)
+        bpy.context.view_layer.objects.active = obj
+        obj.name = f"point_t_{i}"
+        material = get_material(colors[i], no_illumination=True)
+        if obj.data.materials:
+            obj.data.materials[0] = material
+            obj.data = obj.data.copy()
+        else:
+            obj.data.materials.append(material)
+        points.append(obj)
+
+    # Assign their position based on the frames
+    for f in range(frames):
+        for i, point in enumerate(positions[f]):
+            points[i].location = point
+            points[i].keyframe_insert(data_path="location", frame=f + 1)
+
+
+def render_orientations(data, scale):
+    if data is None or scale is None:
         raise ValueError("Render orientations: Data or scale is None.")
 
     quaternions = []
     positions = []
-    for i in range(0, len(MESSAGE_DATA), 7):  # 3 (positions) + 4 (quaternions)
-        pos = MESSAGE_DATA[i : i + 3]
-        quat = MESSAGE_DATA[i + 3 : i + 7]
+    for i in range(0, len(data), 7):  # 3 (positions) + 4 (quaternions)
+        pos = data[i : i + 3]
+        quat = data[i + 3 : i + 7]
         quaternions.append(mathutils.Quaternion([quat[0], quat[1], quat[2], quat[3]]))
         positions.append(mathutils.Vector([pos[0], pos[1], pos[2]]))
 
     scales = []
-    for i in range(0, len(MESSAGE_SCALE), 1):
-        scale = MESSAGE_SCALE[i]
-        scales.append(scale)
+    for i in range(0, len(scale), 1):
+        scale_i = scale[i]
+        scales.append(scale_i)
+
+    # Create a new collection
+    orientations_collection = bpy.data.collections.new(name="Orientations")
+    bpy.context.scene.collection.children.link(orientations_collection)
 
     for i, quat in enumerate(quaternions):
         bpy.ops.object.empty_add(type="ARROWS", location=positions[i])
         obj = bpy.context.object
+        orientations_collection.objects.link(obj)
         obj.name = "orientation_{}".format(i)
         obj.rotation_mode = "QUATERNION"
         obj.rotation_quaternion = quat
         obj.scale = (scales[i], scales[i], scales[i])
 
 
-def render_bvh():
-    global MESSAGE_DATA, MESSAGE_COLOR, MESSAGE_SCALE
-    if MESSAGE_DATA is None or MESSAGE_COLOR is None or MESSAGE_SCALE is None:
+def render_bvh(data, color, scale):
+    if data is None or color is None or scale is None:
         raise ValueError("Render BVH: Data, color or scale is None.")
 
-    data = MESSAGE_DATA.split(".bvh")
+    data = data.split(".bvh")
     if len(data) != 2:
         raise ValueError("Invalid BVH data format.")
     bvh_path = data[0] + ".bvh"
@@ -243,8 +391,12 @@ def render_bvh():
     end_joints = data[:-2]
     axis_forward = data[-2]
     axis_up = data[-1]
-    color = (MESSAGE_COLOR[0], MESSAGE_COLOR[1], MESSAGE_COLOR[2])
-    should_delete_file = MESSAGE_SCALE[0] == 1
+    color = (
+        color[0],
+        color[1],
+        color[2],
+    )
+    should_delete_file = scale[0] == 1
 
     bpy.data.scenes["Scene"].frame_end = 1
     bpy.ops.object.select_all(action="DESELECT")
@@ -268,41 +420,66 @@ def render_bvh():
     generate_rig_representation(bpy.context.active_object, color, end_joints=end_joints)
 
 
-def render_checkerboard_floor():
-    global MESSAGE_DATA
-    if MESSAGE_DATA is None:
+def render_checkerboard_floor(data):
+    if data is None:
         raise ValueError("Render checkerboard floor: Data is None.")
 
-    plane_size = MESSAGE_DATA[0]
-    checker_size = MESSAGE_DATA[1]
-    color1 = (MESSAGE_DATA[2], MESSAGE_DATA[3], MESSAGE_DATA[4], 1.0)
-    color2 = (MESSAGE_DATA[5], MESSAGE_DATA[6], MESSAGE_DATA[7], 1.0)
+    plane_size = data[0]
+    checker_size = data[1]
+    color1 = (
+        data[2],
+        data[3],
+        data[4],
+        1.0,
+    )
+    color2 = (
+        data[5],
+        data[6],
+        data[7],
+        1.0,
+    )
 
     create_checkerboard_plane(plane_size, checker_size, color1, color2)
 
 
-def get_material(color_rgb):  # Function to get or create material
-    global MATERIAL_CACHE
+def get_material(
+    color_rgb, no_illumination=False
+):  # Function to get or create material
+    if color_rgb in SERVER_STATE["material_cache"]:
+        return SERVER_STATE["material_cache"][color_rgb]  # Reuse existing material
 
-    if color_rgb in MATERIAL_CACHE:
-        return MATERIAL_CACHE[color_rgb]  # Reuse existing material
-
-    material = bpy.data.materials.new(name=f"PyMotionMat_{color_rgb}")  # Create new material
+    material = bpy.data.materials.new(
+        name=f"PyMotionMat_{color_rgb}"
+    )  # Create new material
     material.use_nodes = True
-    principled_bsdf = material.node_tree.nodes["Principled BSDF"]
-    principled_bsdf.inputs["Base Color"].default_value = (
-        color_rgb[0],
-        color_rgb[1],
-        color_rgb[2],
-        1.0,
-    )  # RGBA (alpha 1.0)
-    MATERIAL_CACHE[color_rgb] = material  # Store in cache
+    if no_illumination:
+        background_node = material.node_tree.nodes.new(type="ShaderNodeBackground")
+        background_node.inputs["Color"].default_value = (
+            color_rgb[0],
+            color_rgb[1],
+            color_rgb[2],
+            1.0,
+        )  # RGBA (alpha 1.0)
+        material.node_tree.links.new(
+            material.node_tree.nodes["Material Output"].inputs["Surface"],
+            background_node.outputs["Background"],
+        )
+    else:
+        principled_bsdf = material.node_tree.nodes["Principled BSDF"]
+        principled_bsdf.inputs["Base Color"].default_value = (
+            color_rgb[0],
+            color_rgb[1],
+            color_rgb[2],
+            1.0,
+        )  # RGBA (alpha 1.0)
+
+    SERVER_STATE["material_cache"][color_rgb] = material  # Store in cache
     return material
 
 
 def generate_rig_representation(armature_obj, color, end_joints=None):
     if armature_obj.type != "ARMATURE":
-        print("Selected object is not an armature!")
+        print("[PyMotion Blender] Selected object is not an armature!")
         return
 
     bpy.ops.object.mode_set(mode="OBJECT")
@@ -318,10 +495,22 @@ def generate_rig_representation(armature_obj, color, end_joints=None):
 
     bones = armature_obj.data.bones
     for bone in bones:
+        if "twist" in bone.name:  # HARDCODED
+            continue
+
         head_location = armature_obj.matrix_world @ bone.head_local
         tail_location = armature_obj.matrix_world @ bone.tail_local
 
-        sphere_head = create_sphere_at_location(head_location, 0.04, bone.name)
+        base_head_radius = 0.04
+        base_cylinder_radius = 0.02
+
+        distance_factor = (head_location - tail_location).length / 0.2
+        distance_factor = min(1, math.exp(distance_factor) - 1)
+        # TODO: ideally the distance_factor for the sphere is a mix between the previous bone and the current one
+
+        sphere_head = create_sphere_at_location(
+            head_location, base_head_radius * distance_factor, bone.name
+        )
         sphere_head.data.materials.append(material)
         sphere_current_collection = sphere_head.users_collection[0]
         # Link the new object to the collection
@@ -333,7 +522,13 @@ def generate_rig_representation(armature_obj, color, end_joints=None):
         if end_joints is not None and bone.name in end_joints:
             continue
 
-        cylinder = create_cylinder_between_points(bone, head_location, tail_location, 0.02, bone.name)
+        cylinder = create_cylinder_between_points(
+            bone,
+            head_location,
+            tail_location,
+            base_cylinder_radius * distance_factor,
+            bone.name,
+        )
         cylinder.data.materials.append(material)
         cylinder_current_collection = cylinder.users_collection[0]
         rig_collection.objects.link(cylinder)
@@ -355,7 +550,9 @@ def create_sphere_at_location(location, radius=0.1, name="Sphere"):
     obj.select_set(True)
 
     bm = bmesh.new()
-    bmesh.ops.create_uvsphere(bm, u_segments=32, v_segments=16, radius=radius, calc_uvs=True)
+    bmesh.ops.create_uvsphere(
+        bm, u_segments=32, v_segments=16, radius=radius, calc_uvs=True
+    )
     bm.to_mesh(mesh)
     bm.free()
 
@@ -376,15 +573,19 @@ def create_cylinder_between_points(bone, p1, p2, radius=0.2, name="Cylinder"):
     obj.select_set(True)
 
     bm = bmesh.new()
-    bmesh.ops.create_cone(bm, cap_ends=True, segments=5, radius1=radius, radius2=radius, depth=length)
+    bmesh.ops.create_cone(
+        bm, cap_ends=True, segments=5, radius1=radius, radius2=radius, depth=length
+    )
     bm.to_mesh(mesh)
     bm.free()
 
     # Position it
     obj.location = (p1 + p2) / 2
-    rotation_difference = direction.rotation_difference(mathutils.Vector((0, 0, 1)))
-    r = rotation_difference.to_euler()
-    obj.rotation_euler = mathutils.Vector((-r.x, -r.y, -r.z))
+    # Align local Z to direction
+    up = mathutils.Vector((0, 0, 1))
+    quat = up.rotation_difference(direction.normalized())
+    obj.rotation_mode = "QUATERNION"
+    obj.rotation_quaternion = quat
 
     return obj
 
@@ -395,7 +596,9 @@ def setup_constraints(obj, target_bone_name, armature_object):
     constraint.subtarget = target_bone_name
 
 
-def create_checkerboard_plane(plane_size=2, checker_size=1, color1=(1, 1, 1, 1), color2=(0, 0, 0, 1)):
+def create_checkerboard_plane(
+    plane_size=2, checker_size=1, color1=(1, 1, 1, 1), color2=(0, 0, 0, 1)
+):
     """
     Create a plane with a checkerboard pattern in Blender.
 
@@ -435,90 +638,59 @@ def create_checkerboard_plane(plane_size=2, checker_size=1, color1=(1, 1, 1, 1),
     return plane
 
 
-def check_messages():
-    global MESSAGE_ID, MESSAGE_DATA, MESSAGE_COLOR, MESSAGE_SCALE
-    if MESSAGE_ID is not None:
-        if MESSAGE_ID == 0:
-            clear_scene()
-        elif MESSAGE_ID == 1:
-            render_points()
-        elif MESSAGE_ID == 2:
-            render_orientations()
-        elif MESSAGE_ID == 3:
-            render_bvh()
-        elif MESSAGE_ID == 4:
-            render_checkerboard_floor()
-        else:
-            print(f"Unknown message id {MESSAGE_ID}")
-        MESSAGE_ID = None
-        MESSAGE_DATA = None
-        MESSAGE_COLOR = None
-        MESSAGE_SCALE = None
-    return 0.1  # Timer interval (check for messages every 0.1 seconds)
-
-
+# --- SERVER STARTUP AND REGISTRATION ---
 def start_server():
-    global FINISH_THREAD, RECEIVE_THREAD
-    if not init_socket():  # Initialize socket and check for success
-        print("Failed to initialize socket. Server not starting.")
+    """Initializes the socket and starts the network thread."""
+    if SERVER_STATE["receive_thread"] and SERVER_STATE["receive_thread"].is_alive():
+        print("[PyMotion Main] Server is already running.")
         return
 
-    FINISH_THREAD = False
-    RECEIVE_THREAD = Thread(target=receive_messages, daemon=True)
-    RECEIVE_THREAD.start()
-    bpy.app.timers.register(check_messages)  # Start timer to periodically check for messages
-    clear_scene()
+    try:
+        port_str = sys.argv[sys.argv.index("--") + 1]
+        SERVER_STATE["port"] = int(port_str)
+    except (ValueError, IndexError):
+        print(f"[PyMotion Main] Using default port {SERVER_STATE['port']}")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((SERVER_STATE["host"], SERVER_STATE["port"]))
+        sock.listen()
+        SERVER_STATE["socket"] = sock
+    except Exception as e:
+        print(f"[PyMotion Main] FATAL: Could not bind to socket: {e}")
+        return
+
+    SERVER_STATE["finish_thread"] = False
+    thread = Thread(target=receive_messages, daemon=True)
+    thread.start()
+    SERVER_STATE["receive_thread"] = thread
+    print("[PyMotion Main] Server started successfully.")
 
 
-def stop_server():
-    global FINISH_THREAD, RECEIVE_THREAD
-    FINISH_THREAD = True
-    if RECEIVE_THREAD:
-        RECEIVE_THREAD.join(timeout=2)  # Wait for thread to finish (with timeout)
-        if RECEIVE_THREAD.is_alive():
-            print("Warning: Receive thread did not terminate gracefully.")
-    if CONN:
-        CONN.close()
-    if SOCKET:
-        SOCKET.close()
-
-
-class StartPyMotionServerOperator(bpy.types.Operator):
-    bl_idname = "object.start_pymotion_server"
-    bl_label = "Start PyMotion Server"
-
-    def execute(self, context):
-        start_server()
-        return {"FINISHED"}
-
-
-class StopPyMotionServerOperator(bpy.types.Operator):
-    bl_idname = "object.stop_pymotion_server"
-    bl_label = "Stop PyMotion Server"
-
-    def execute(self, context):
-        stop_server()
-        return {"FINISHED"}
-
-
-def menu_func(self, context):
-    layout = self.layout
-    layout.operator(StartPyMotionServerOperator.bl_idname, text="Start PyMotion Server")
-    layout.operator(StopPyMotionServerOperator.bl_idname, text="Stop PyMotion Server")
+# We don't need the full Operator class anymore, but we need a way to register the script
+# This is now much simpler.
+class PyMotionPreferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
 
 
 def register():
-    bpy.utils.register_class(StartPyMotionServerOperator)
-    bpy.utils.register_class(StopPyMotionServerOperator)
-    bpy.types.VIEW3D_MT_object.append(menu_func)
+    start_server()
 
 
 def unregister():
-    bpy.utils.unregister_class(StartPyMotionServerOperator)
-    bpy.utils.unregister_class(StopPyMotionServerOperator)
-    bpy.types.VIEW3D_MT_object.remove(menu_func)
+    print("[PyMotion Main] Unregistering and stopping server.")
+    SERVER_STATE["finish_thread"] = True
+    # Unblock the accept() call
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as dummy_socket:
+            dummy_socket.connect((SERVER_STATE["host"], SERVER_STATE["port"]))
+    except:
+        pass
+    if SERVER_STATE["socket"]:
+        SERVER_STATE["socket"].close()
 
 
 if __name__ == "__main__":
-    register()
+    # When Blender starts with -P, this block runs.
     start_server()

--- a/pymotion/rotations/dual_quat.py
+++ b/pymotion/rotations/dual_quat.py
@@ -13,8 +13,8 @@ The first 4 elements are the real part and the last 4 elements are the dual part
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None

--- a/pymotion/rotations/dual_quat.py
+++ b/pymotion/rotations/dual_quat.py
@@ -1,121 +1,132 @@
-import numpy as np
-from . import quat
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
 
 """
+Unified dual quaternion operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for dual quaternion operations
+regardless of the underlying array library being used.
+
 Dual quaternions are represented as arrays of shape [..., 8]
 where the last dimension is the dual quaternion representation.
 The first 4 elements are the real part and the last 4 elements are the dual part.
 [..., [w_r, x_r, y_r, z_r, w_d, x_d, y_d, z_d]]
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
 """
+from __future__ import annotations
 
 
-def from_rotation_translation(rotations: np.array, translations: np.array) -> np.array:
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_dual_quat_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import dual_quat_torch as _dual_quat_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_dual_quat_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import dual_quat_np as _dual_quat_np
+except ImportError:
+    pass
+
+
+# Explicit wrapper functions with full documentation
+def from_rotation_translation(rotations, translations):
     """
     Convert the rotations (quaternions) and translation (3D vectors) information to dual quaternions.
 
     Parameters
     ----------
-    rotations: np.array[..., [w, x, y, z]]]
-    translations : np.array[..., 3]
+    rotations : torch.Tensor or np.array[..., [w, x, y, z]]
+        Rotation quaternions
+    translations : torch.Tensor or np.array[..., 3]
+        Translation vectors
 
     Returns
     -------
-    dq : np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Dual quaternions
     """
-    # dual quaternion (sigma) = qr + qd (+ is not an addition, but concatenation)
-    # real part of dual quaternions represent rotations
-    # and is represented as a conventional unit quaternion
-    q_r = rotations
-    # dual part of dual quaternions represent translations
-    # t is a pure quaternion (0, x, y, z)
-    # q_d = 0.5 * eps * t * q_r
-    t = np.zeros((translations.shape[:-1] + (4,)))
-    t[..., 1:] = translations
-    q_d = 0.5 * quat.mul(t, q_r)
-    dq = np.concatenate((q_r, q_d), axis=-1)
-    return dq
+    if _TorchTensor is not None and isinstance(rotations, _TorchTensor):
+        return _dual_quat_torch.from_rotation_translation(rotations, translations)
+    else:
+        return _dual_quat_np.from_rotation_translation(rotations, translations)
 
 
-def from_translation(translations: np.array) -> np.array:
+def from_translation(translations):
     """
     Convert a translation to a dual quaternion.
 
     Parameters
     ----------
-    translations : np.array[..., 3]
+    translations : torch.Tensor or np.array[..., 3]
+        Translation vectors
 
     Returns
     -------
-    dual_quats : np.array[..., 8]
+    dual_quats : torch.Tensor or np.array[..., 8]
+        Dual quaternions
     """
-    dual_quats = np.zeros((translations.shape[:-1] + (8,)))
-    # real part of dual quaternions represent rotations
-    # and is represented as a conventional unit quaternion
-    dual_quats[..., 0:1] = 1
-    # dual part of dual quaternions represent translations
-    # t is a pure quaternion (0, x, y, z)
-    # q_d = 0.5 * eps * t * q_r (q_r = 1, thus, q_d = 0.5 * eps * t)
-    dual_quats[..., 5:] = translations * 0.5
-    return dual_quats
+    if _TorchTensor is not None and isinstance(translations, _TorchTensor):
+        return _dual_quat_torch.from_translation(translations)
+    else:
+        return _dual_quat_np.from_translation(translations)
 
 
-def to_rotation_translation(dq: np.array) -> np.array:
+def to_rotation_translation(dq):
     """
     Convert a dual quaternion to the rotations (quaternions) and translations (3D vectors).
 
     Parameters
     ----------
-    dq: np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Dual quaternions
 
     Returns
     -------
-    rotations: np.array[..., [w, x, y, z]]]
-    translations: np.array[..., 3]
+    rotations : torch.Tensor or np.array[..., [w, x, y, z]]
+        Rotation quaternions
+    translations : torch.Tensor or np.array[..., 3]
+        Translation vectors
     """
-    dq = dq.copy()
-    q_r = dq[..., :4]
-    # rotations can ge get directly from the real part of the dual quaternion
-    rotations = q_r
-    q_d = dq[..., 4:]
-    # the translation (pure quaternion) t = 2 * q_d * q_r*
-    # where q_r* is the conjugate of q_r
-    translations = (2 * quat.mul(q_d, quat.conjugate(q_r)))[..., 1:]
-    return rotations, translations
+    if _TorchTensor is not None and isinstance(dq, _TorchTensor):
+        return _dual_quat_torch.to_rotation_translation(dq)
+    else:
+        return _dual_quat_np.to_rotation_translation(dq)
 
 
-def normalize(dq: np.array) -> np.array:
+def normalize(dq):
     """
     Normalize the dual quaternion to unit length and make sure that
     the dual part is orthogonal to the real part (unit dual quaternion).
 
     Parameters
     ----------
-    dq: np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Dual quaternions
 
     Returns
     -------
-    dq: np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Normalized dual quaternions
     """
-    dq = dq.copy()
-    q_r = dq[..., :4]
-    q_d = dq[..., 4:]
-    norm = np.linalg.norm(q_r, axis=-1)
-    qnorm = np.stack((norm, norm, norm, norm), axis=-1)
-    q_r_normalized = q_r / qnorm
-    q_d_normalized = q_d / qnorm
-    if not is_unit(np.concatenate((q_r_normalized, q_d_normalized), axis=-1)):
-        # make sure that the dual quaternion is orthogonal to the real quaternion
-        dot_q_r_q_d = np.sum(q_r * q_d, axis=-1)  # dot product of q_r and q_d
-        q_d_normalized_ortho = q_d_normalized - (
-            q_r_normalized * (dot_q_r_q_d / (norm * norm))[..., np.newaxis]
-        )
-        dq = np.concatenate((q_r_normalized, q_d_normalized_ortho), axis=-1)
+    if _TorchTensor is not None and isinstance(dq, _TorchTensor):
+        return _dual_quat_torch.normalize(dq)
     else:
-        dq = np.concatenate((q_r_normalized, q_d_normalized), axis=-1)
-    return dq
+        return _dual_quat_np.normalize(dq)
 
 
-def is_unit(dq: np.array, atol: float = 1e-03) -> bool:
+def is_unit(dq, atol=1e-03):
     """
     Check if the dual quaternion is a unit one.
     A unit dual quaternion satisfies two properties:
@@ -124,19 +135,23 @@ def is_unit(dq: np.array, atol: float = 1e-03) -> bool:
 
     Parameters
     ----------
-    dq: np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Dual quaternions
+    atol : float, optional
+        Absolute tolerance for the check. Default is 1e-03.
+
+    Returns
+    -------
+    is_unit : bool
+        True if the dual quaternion is a unit one
     """
-    q_r = dq[..., :4]
-    q_d = dq[..., 4:]
-    sqr_norm_q_r = np.sum(q_r * q_r, axis=-1)
-    if np.isclose(sqr_norm_q_r, 0).all():
-        return True
-    rot_normalized = np.isclose(sqr_norm_q_r, 1).all()
-    trans_normalized = np.isclose(np.sum(q_r * q_d, axis=-1), 0, atol=atol).all()
-    return rot_normalized and trans_normalized
+    if _TorchTensor is not None and isinstance(dq, _TorchTensor):
+        return _dual_quat_torch.is_unit(dq, atol)
+    else:
+        return _dual_quat_np.is_unit(dq, atol)
 
 
-def unroll(dq: np.array, axis: int) -> np.array:
+def unroll(dq, axis):
     """
     Enforce dual quaternion continuity across the time dimension by selecting
     the representation (dq or -dq) with minimal distance (or, equivalently, maximal dot product)
@@ -144,24 +159,28 @@ def unroll(dq: np.array, axis: int) -> np.array:
 
     Parameters
     ----------
-    dq : np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Dual quaternions
     axis : int
-        unroll axis (e.g., frames axis)
+        Unroll axis (e.g., frames axis)
 
     Returns
     -------
-    dq : np.array[..., 8]
+    dq : torch.Tensor or np.array[..., 8]
+        Unrolled dual quaternions
     """
-    dq = dq.swapaxes(0, axis)
-    q_r = dq[..., :4]
-    # start with the second quaternion since
-    # we keep the cover of the first one
-    for i in range(1, len(q_r)):
-        # distance (dot product) between the previous and current quaternion
-        d0 = np.sum(q_r[i] * q_r[i - 1], axis=-1)
-        # distance (dot product) between the previous and flipped current quaternion
-        d1 = np.sum(-q_r[i] * q_r[i - 1], axis=-1)
-        # if the distance with the flipped quaternion is smaller, use it
-        dq[i][d0 < d1] = -dq[i][d0 < d1]
-    dq = dq.swapaxes(0, axis)
-    return dq
+    if _TorchTensor is not None and isinstance(dq, _TorchTensor):
+        return _dual_quat_torch.unroll(dq, axis)
+    else:
+        return _dual_quat_np.unroll(dq, axis)
+
+
+# Expose public API
+__all__ = [
+    "from_rotation_translation",
+    "from_translation",
+    "to_rotation_translation",
+    "normalize",
+    "is_unit",
+    "unroll",
+]

--- a/pymotion/rotations/dual_quat_np.py
+++ b/pymotion/rotations/dual_quat_np.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import numpy as np
+
+from . import quat_np as quat
+
+"""
+Dual quaternions are represented as arrays of shape [..., 8]
+where the last dimension is the dual quaternion representation.
+The first 4 elements are the real part and the last 4 elements are the dual part.
+[..., [w_r, x_r, y_r, z_r, w_d, x_d, y_d, z_d]]
+"""
+
+
+def from_rotation_translation(rotations: np.array, translations: np.array) -> np.array:
+    """
+    Convert the rotations (quaternions) and translation (3D vectors) information to dual quaternions.
+
+    Parameters
+    ----------
+    rotations: np.array[..., [w, x, y, z]]]
+    translations : np.array[..., 3]
+
+    Returns
+    -------
+    dq : np.array[..., 8]
+    """
+    # dual quaternion (sigma) = qr + qd (+ is not an addition, but concatenation)
+    # real part of dual quaternions represent rotations
+    # and is represented as a conventional unit quaternion
+    q_r = rotations
+    # dual part of dual quaternions represent translations
+    # t is a pure quaternion (0, x, y, z)
+    # q_d = 0.5 * eps * t * q_r
+    t = np.zeros((translations.shape[:-1] + (4,)))
+    t[..., 1:] = translations
+    q_d = 0.5 * quat.mul(t, q_r)
+    dq = np.concatenate((q_r, q_d), axis=-1)
+    return dq
+
+
+def from_translation(translations: np.array) -> np.array:
+    """
+    Convert a translation to a dual quaternion.
+
+    Parameters
+    ----------
+    translations : np.array[..., 3]
+
+    Returns
+    -------
+    dual_quats : np.array[..., 8]
+    """
+    dual_quats = np.zeros((translations.shape[:-1] + (8,)))
+    # real part of dual quaternions represent rotations
+    # and is represented as a conventional unit quaternion
+    dual_quats[..., 0:1] = 1
+    # dual part of dual quaternions represent translations
+    # t is a pure quaternion (0, x, y, z)
+    # q_d = 0.5 * eps * t * q_r (q_r = 1, thus, q_d = 0.5 * eps * t)
+    dual_quats[..., 5:] = translations * 0.5
+    return dual_quats
+
+
+def to_rotation_translation(dq: np.array) -> np.array:
+    """
+    Convert a dual quaternion to the rotations (quaternions) and translations (3D vectors).
+
+    Parameters
+    ----------
+    dq: np.array[..., 8]
+
+    Returns
+    -------
+    rotations: np.array[..., [w, x, y, z]]]
+    translations: np.array[..., 3]
+    """
+    dq = dq.copy()
+    q_r = dq[..., :4]
+    # rotations can ge get directly from the real part of the dual quaternion
+    rotations = q_r
+    q_d = dq[..., 4:]
+    # the translation (pure quaternion) t = 2 * q_d * q_r*
+    # where q_r* is the conjugate of q_r
+    translations = (2 * quat.mul(q_d, quat.conjugate(q_r)))[..., 1:]
+    return rotations, translations
+
+
+def normalize(dq: np.array) -> np.array:
+    """
+    Normalize the dual quaternion to unit length and make sure that
+    the dual part is orthogonal to the real part (unit dual quaternion).
+
+    Parameters
+    ----------
+    dq: np.array[..., 8]
+
+    Returns
+    -------
+    dq: np.array[..., 8]
+    """
+    dq = dq.copy()
+    q_r = dq[..., :4]
+    q_d = dq[..., 4:]
+    norm = np.linalg.norm(q_r, axis=-1)
+    qnorm = np.stack((norm, norm, norm, norm), axis=-1)
+    q_r_normalized = q_r / qnorm
+    q_d_normalized = q_d / qnorm
+    if not is_unit(np.concatenate((q_r_normalized, q_d_normalized), axis=-1)):
+        # make sure that the dual quaternion is orthogonal to the real quaternion
+        dot_q_r_q_d = np.sum(q_r * q_d, axis=-1)  # dot product of q_r and q_d
+        q_d_normalized_ortho = q_d_normalized - (
+            q_r_normalized * (dot_q_r_q_d / (norm * norm))[..., np.newaxis]
+        )
+        dq = np.concatenate((q_r_normalized, q_d_normalized_ortho), axis=-1)
+    else:
+        dq = np.concatenate((q_r_normalized, q_d_normalized), axis=-1)
+    return dq
+
+
+def is_unit(dq: np.array, atol: float = 1e-03) -> bool:
+    """
+    Check if the dual quaternion is a unit one.
+    A unit dual quaternion satisfies two properties:
+    - The norm of the real part is 1
+    - The dot product of the real and dual part is 0.
+
+    Parameters
+    ----------
+    dq: np.array[..., 8]
+    """
+    q_r = dq[..., :4]
+    q_d = dq[..., 4:]
+    sqr_norm_q_r = np.sum(q_r * q_r, axis=-1)
+    if np.isclose(sqr_norm_q_r, 0).all():
+        return True
+    rot_normalized = np.isclose(sqr_norm_q_r, 1).all()
+    trans_normalized = np.isclose(np.sum(q_r * q_d, axis=-1), 0, atol=atol).all()
+    return rot_normalized and trans_normalized
+
+
+def unroll(dq: np.array, axis: int) -> np.array:
+    """
+    Enforce dual quaternion continuity across the time dimension by selecting
+    the representation (dq or -dq) with minimal distance (or, equivalently, maximal dot product)
+    between two consecutive frames.
+
+    Parameters
+    ----------
+    dq : np.array[..., 8]
+    axis : int
+        unroll axis (e.g., frames axis)
+
+    Returns
+    -------
+    dq : np.array[..., 8]
+    """
+    dq = dq.swapaxes(0, axis)
+    q_r = dq[..., :4]
+    # start with the second quaternion since
+    # we keep the cover of the first one
+    for i in range(1, len(q_r)):
+        # distance (dot product) between the previous and current quaternion
+        d0 = np.sum(q_r[i] * q_r[i - 1], axis=-1)
+        # distance (dot product) between the previous and flipped current quaternion
+        d1 = np.sum(-q_r[i] * q_r[i - 1], axis=-1)
+        # if the distance with the flipped quaternion is smaller, use it
+        dq[i][d0 < d1] = -dq[i][d0 < d1]
+    dq = dq.swapaxes(0, axis)
+    return dq

--- a/pymotion/rotations/ortho6d.py
+++ b/pymotion/rotations/ortho6d.py
@@ -15,8 +15,8 @@ Matrix order: [[r0.x, r0.y],
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None

--- a/pymotion/rotations/ortho6d.py
+++ b/pymotion/rotations/ortho6d.py
@@ -1,90 +1,142 @@
-import numpy as np
-from . import quat
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
 
 """
-Ortho6D are represented as arrays of shape [..., 3, 2]
+Unified ortho6D operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for ortho6D operations
+regardless of the underlying array library being used.
+
+Ortho6D are represented as tensors of shape [..., 3, 2]
 where the last dimension is the ortho6D representations,
 which is the first two columns of the rotation matrix.
 Matrix order: [[r0.x, r0.y],
                [r1.x, r1.y],
                [r2.x, r2.y]] where ri is row i.
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
 """
+from __future__ import annotations
 
 
-def from_quat(quaternions: np.array) -> np.array:
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_ortho6d_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import ortho6d_torch as _ortho6d_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_ortho6d_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import ortho6d_np as _ortho6d_np
+except ImportError:
+    pass
+
+
+# Explicit wrapper functions with full documentation
+def from_quat(quaternions):
     """
-    Convert quaternions to otho6D representation.
+    Convert quaternions to ortho6D representation.
 
     Parameters
     ----------
-        quat : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
-                                                     [r1.x, r1.y],
-                                                     [r2.x, r2.y]] where ri is row i.
+    ortho6D: torch.Tensor or np.array[..., 3, 2]
+        Matrix order: [[r0.x, r0.y],
+                       [r1.x, r1.y],
+                       [r2.x, r2.y]] where ri is row i.
     """
-    return from_matrix(quat.to_matrix(quaternions))
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _ortho6d_torch.from_quat(quaternions)
+    else:
+        return _ortho6d_np.from_quat(quaternions)
 
 
-def from_matrix(rotmats: np.array) -> np.array:
+def from_matrix(rotmats):
     """
     Convert rotation matrices to ortho6D representation.
 
     Parameters
     ----------
-        rotmats : np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                      [r1.x, r1.y, r1.z],
-                                                      [r2.x, r2.y, r2.z]] where ri is row i.
+    rotmats : torch.Tensor or np.array[..., 3, 3]
+        Matrix order: [[r0.x, r0.y, r0.z],
+                       [r1.x, r1.y, r1.z],
+                       [r2.x, r2.y, r2.z]] where ri is row i.
 
     Returns
     -------
-        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
-                                                     [r1.x, r1.y],
-                                                     [r2.x, r2.y]] where ri is row i.
+    ortho6D: torch.Tensor or np.array[..., 3, 2]
+        Matrix order: [[r0.x, r0.y],
+                       [r1.x, r1.y],
+                       [r2.x, r2.y]] where ri is row i.
     """
-    return rotmats[..., :2]
+    if _TorchTensor is not None and isinstance(rotmats, _TorchTensor):
+        return _ortho6d_torch.from_matrix(rotmats)
+    else:
+        return _ortho6d_np.from_matrix(rotmats)
 
 
-def to_quat(ortho6D: np.array) -> np.array:
+def to_quat(ortho6D):
     """
     Convert ortho6D to quaternions.
 
     Parameters
     ----------
-        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
-                                                     [r1.x, r1.y],
-                                                     [r2.x, r2.y]] where ri is row i.
+    ortho6D: torch.Tensor or np.array[..., 3, 2]
+        Matrix order: [[r0.x, r0.y],
+                       [r1.x, r1.y],
+                       [r2.x, r2.y]] where ri is row i.
 
     Returns
     -------
-        quat : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    return quat.from_matrix(to_matrix(ortho6D))
+    if _TorchTensor is not None and isinstance(ortho6D, _TorchTensor):
+        return _ortho6d_torch.to_quat(ortho6D)
+    else:
+        return _ortho6d_np.to_quat(ortho6D)
 
 
-def to_matrix(ortho6D: np.array) -> np.array:
+def to_matrix(ortho6D):
     """
     Convert ortho6D to rotation matrices.
 
     Parameters
     ----------
-        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
-                                                     [r1.x, r1.y],
-                                                     [r2.x, r2.y]] where ri is row i.
+    ortho6D: torch.Tensor or np.array[..., 3, 2]
+        Matrix order: [[r0.x, r0.y],
+                       [r1.x, r1.y],
+                       [r2.x, r2.y]] where ri is row i.
 
     Returns
     -------
-        rotmats : np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                      [r1.x, r1.y, r1.z],
-                                                      [r2.x, r2.y, r2.z]] where ri is row i.
+    rotmats : torch.Tensor or np.array[..., 3, 3]
+        Matrix order: [[r0.x, r0.y, r0.z],
+                       [r1.x, r1.y, r1.z],
+                       [r2.x, r2.y, r2.z]] where ri is row i.
     """
-    c1 = ortho6D[..., 0] / np.linalg.norm(ortho6D[..., 0], axis=-1, keepdims=True)
-    c2 = ortho6D[..., 1] - np.sum(c1 * ortho6D[..., 1], axis=-1)[..., np.newaxis] * c1
-    c2 = c2 / np.linalg.norm(c2, axis=-1, keepdims=True)
-    c3 = np.cross(c1, c2, axis=-1)
-    rotations = np.concatenate([c1, c2, c3], axis=-1).reshape(*ortho6D.shape[:-2], 3, 3)
-    # transpose last 2 axis
-    rotations = np.swapaxes(rotations, -2, -1)
-    return rotations
+    if _TorchTensor is not None and isinstance(ortho6D, _TorchTensor):
+        return _ortho6d_torch.to_matrix(ortho6D)
+    else:
+        return _ortho6d_np.to_matrix(ortho6D)
+
+
+# Expose public API
+__all__ = [
+    "from_quat",
+    "from_matrix",
+    "to_quat",
+    "to_matrix",
+]

--- a/pymotion/rotations/ortho6d_np.py
+++ b/pymotion/rotations/ortho6d_np.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import numpy as np
+
+from . import quat_np as quat
+
+"""
+Ortho6D are represented as arrays of shape [..., 3, 2]
+where the last dimension is the ortho6D representations,
+which is the first two columns of the rotation matrix.
+Matrix order: [[r0.x, r0.y],
+               [r1.x, r1.y],
+               [r2.x, r2.y]] where ri is row i.
+"""
+
+
+def from_quat(quaternions: np.array) -> np.array:
+    """
+    Convert quaternions to otho6D representation.
+
+    Parameters
+    ----------
+        quat : np.array[..., [w,x,y,z]]
+
+    Returns
+    -------
+        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
+                                                     [r1.x, r1.y],
+                                                     [r2.x, r2.y]] where ri is row i.
+    """
+    return from_matrix(quat.to_matrix(quaternions))
+
+
+def from_matrix(rotmats: np.array) -> np.array:
+    """
+    Convert rotation matrices to ortho6D representation.
+
+    Parameters
+    ----------
+        rotmats : np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
+                                                      [r1.x, r1.y, r1.z],
+                                                      [r2.x, r2.y, r2.z]] where ri is row i.
+
+    Returns
+    -------
+        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
+                                                     [r1.x, r1.y],
+                                                     [r2.x, r2.y]] where ri is row i.
+    """
+    return rotmats[..., :2]
+
+
+def to_quat(ortho6D: np.array) -> np.array:
+    """
+    Convert ortho6D to quaternions.
+
+    Parameters
+    ----------
+        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
+                                                     [r1.x, r1.y],
+                                                     [r2.x, r2.y]] where ri is row i.
+
+    Returns
+    -------
+        quat : np.array[..., [w,x,y,z]]
+    """
+    return quat.from_matrix(to_matrix(ortho6D))
+
+
+def to_matrix(ortho6D: np.array) -> np.array:
+    """
+    Convert ortho6D to rotation matrices.
+
+    Parameters
+    ----------
+        ortho6D: np.array[..., 3, 2]. Matrix order: [[r0.x, r0.y],
+                                                     [r1.x, r1.y],
+                                                     [r2.x, r2.y]] where ri is row i.
+
+    Returns
+    -------
+        rotmats : np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
+                                                      [r1.x, r1.y, r1.z],
+                                                      [r2.x, r2.y, r2.z]] where ri is row i.
+    """
+    c1 = ortho6D[..., 0] / np.linalg.norm(ortho6D[..., 0], axis=-1, keepdims=True)
+    c2 = ortho6D[..., 1] - np.sum(c1 * ortho6D[..., 1], axis=-1)[..., np.newaxis] * c1
+    c2 = c2 / np.linalg.norm(c2, axis=-1, keepdims=True)
+    c3 = np.cross(c1, c2, axis=-1)
+    rotations = np.concatenate([c1, c2, c3], axis=-1).reshape(*ortho6D.shape[:-2], 3, 3)
+    # transpose last 2 axis
+    rotations = np.swapaxes(rotations, -2, -1)
+    return rotations

--- a/pymotion/rotations/quat.py
+++ b/pymotion/rotations/quat.py
@@ -8,8 +8,8 @@ regardless of the underlying array library being used.
 The dispatcher imports backends at module load time. If a library isn't installed,
 its backend will be None and will raise an error at runtime if you try to use it.
 """
-from __future__ import annotations
 
+from __future__ import annotations
 
 # Import type references and backend modules at module import time
 _TorchTensor = None

--- a/pymotion/rotations/quat.py
+++ b/pymotion/rotations/quat.py
@@ -1,52 +1,87 @@
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unified quaternion operations wrapper that dispatches to NumPy or PyTorch backends
+based on input tensor types. This provides a single API for quaternion operations
+regardless of the underlying array library being used.
+
+The dispatcher imports backends at module load time. If a library isn't installed,
+its backend will be None and will raise an error at runtime if you try to use it.
+"""
 from __future__ import annotations
-import numpy as np
-import pymotion.ops.vector as vec
 
 
-def from_scaled_angle_axis(scaledaxis: np.array) -> np.array:
+# Import type references and backend modules at module import time
+_TorchTensor = None
+_quat_torch = None
+
+try:
+    import torch
+
+    _TorchTensor = torch.Tensor
+    from . import quat_torch as _quat_torch
+except ImportError:
+    pass
+
+_NumpyArray = None
+_quat_np = None
+
+try:
+    import numpy as np
+
+    _NumpyArray = np.ndarray
+    from . import quat_np as _quat_np
+except ImportError:
+    pass
+
+
+# Explicit wrapper functions
+def from_scaled_angle_axis(scaledaxis):
     """
     Create a quaternion from an scaled angle-axis representation.
 
     Parameters
     ----------
-    scaledaxis : np.array[..., [x,y,z]]
+    scaledaxis : torch.Tensor or np.array[..., [x,y,z]]
         axis [x,y,z] of rotation where magnitude is the angle of rotation
 
     Returns
     -------
-    quat : np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    angle = np.linalg.norm(scaledaxis, axis=-1)[..., np.newaxis]
-    axis = scaledaxis / angle
-    return from_angle_axis(angle, axis)
+    if _TorchTensor is not None and isinstance(scaledaxis, _TorchTensor):
+        return _quat_torch.from_scaled_angle_axis(scaledaxis)
+    else:
+        return _quat_np.from_scaled_angle_axis(scaledaxis)
 
 
-def from_angle_axis(angle: np.array, axis: np.array) -> np.array:
+def from_angle_axis(angle, axis):
     """
     Create a quaternion from an angle-axis representation.
 
     Parameters
     ----------
-    angle : np.array[..., angle] in radians.
-    axis : np.array[..., [x,y,z]]
+    angle : torch.Tensor or np.array[..., angle] in radians.
+    axis : torch.Tensor or np.array[..., [x,y,z]]
         normalized axis [x,y,z] of rotation
 
     Returns
     -------
-    quat : np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    c = np.cos(angle / 2.0)
-    s = np.sin(angle / 2.0)
-    return np.concatenate((c, s * axis), axis=-1)
+    if _TorchTensor is not None and isinstance(angle, _TorchTensor):
+        return _quat_torch.from_angle_axis(angle, axis)
+    else:
+        return _quat_np.from_angle_axis(angle, axis)
 
 
-def from_euler(euler: np.array, order: np.array) -> np.array:
+def from_euler(euler, order):
     """
     Create a quaternion from an euler representation with a specified order.
 
     Parameters
     ----------
-    euler : np.array[..., [e0, e1, e2]]
+    euler : torch.Tensor or np.array[..., [e0, e1, e2]]
         euler angles in radians
     order : np.array[..., ['x'|'y'|'z', 'x'|'y'|'z', 'x'|'y'|'z']]
         order of the euler angles
@@ -54,376 +89,231 @@ def from_euler(euler: np.array, order: np.array) -> np.array:
 
     Returns
     -------
-    quat : np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-
-    assert (
-        euler.shape[:-1] == order.shape[:-1]
-    ), "euler and order must have the same shape except for the last dimension"
-
-    axis = {
-        "x": np.array([1, 0, 0]),
-        "y": np.array([0, 1, 0]),
-        "z": np.array([0, 0, 1]),
-    }
-
-    q0 = from_angle_axis(
-        euler[..., 0:1],
-        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 0:1]),
-    )
-    q1 = from_angle_axis(
-        euler[..., 1:2],
-        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 1:2]),
-    )
-    q2 = from_angle_axis(
-        euler[..., 2:3],
-        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 2:3]),
-    )
-    return mul(q0, mul(q1, q2))
+    if _TorchTensor is not None and isinstance(euler, _TorchTensor):
+        return _quat_torch.from_euler(euler, order)
+    else:
+        return _quat_np.from_euler(euler, order)
 
 
-def from_matrix(rotmats: np.array) -> np.array:
+def from_matrix(rotmats):
     """
     Convert rotation matrices to quaternions.
 
     Parameters
     ----------
-        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                     [r1.x, r1.y, r1.z],
-                                                     [r2.x, r2.y, r2.z]] where ri is row i.
+    rotmats: torch.Tensor or np.array[..., 3, 3]
+        Matrix order: [[r0.x, r0.y, r0.z],
+                       [r1.x, r1.y, r1.z],
+                       [r2.x, r2.y, r2.z]] where ri is row i.
 
     Returns
     -------
-        quat np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    # Separate components
-    r0c0 = rotmats[..., 0, 0]
-    r0c1 = rotmats[..., 0, 1]
-    r0c2 = rotmats[..., 0, 2]
-    r1c0 = rotmats[..., 1, 0]
-    r1c1 = rotmats[..., 1, 1]
-    r1c2 = rotmats[..., 1, 2]
-    r2c0 = rotmats[..., 2, 0]
-    r2c1 = rotmats[..., 2, 1]
-    r2c2 = rotmats[..., 2, 2]
-
-    return normalize(
-        np.where(
-            (r2c2 < 0.0)[..., np.newaxis],
-            np.where(
-                (r0c0 > r1c1)[..., np.newaxis],
-                np.concatenate(
-                    [
-                        (r2c1 - r1c2)[..., np.newaxis],
-                        (1.0 + r0c0 - r1c1 - r2c2)[..., np.newaxis],
-                        (r1c0 + r0c1)[..., np.newaxis],
-                        (r0c2 + r2c0)[..., np.newaxis],
-                    ],
-                    axis=-1,
-                ),
-                np.concatenate(
-                    [
-                        (r0c2 - r2c0)[..., np.newaxis],
-                        (r1c0 + r0c1)[..., np.newaxis],
-                        (1.0 - r0c0 + r1c1 - r2c2)[..., np.newaxis],
-                        (r2c1 + r1c2)[..., np.newaxis],
-                    ],
-                    axis=-1,
-                ),
-            ),
-            np.where(
-                (r0c0 < -r1c1)[..., np.newaxis],
-                np.concatenate(
-                    [
-                        (r1c0 - r0c1)[..., np.newaxis],
-                        (r0c2 + r2c0)[..., np.newaxis],
-                        (r2c1 + r1c2)[..., np.newaxis],
-                        (1.0 - r0c0 - r1c1 + r2c2)[..., np.newaxis],
-                    ],
-                    axis=-1,
-                ),
-                np.concatenate(
-                    [
-                        (1.0 + r0c0 + r1c1 + r2c2)[..., np.newaxis],
-                        (r2c1 - r1c2)[..., np.newaxis],
-                        (r0c2 - r2c0)[..., np.newaxis],
-                        (r1c0 - r0c1)[..., np.newaxis],
-                    ],
-                    axis=-1,
-                ),
-            ),
-        )
-    )
+    if _TorchTensor is not None and isinstance(rotmats, _TorchTensor):
+        return _quat_torch.from_matrix(rotmats)
+    else:
+        return _quat_np.from_matrix(rotmats)
 
 
-def to_euler(quaternions: np.array, order: np.array) -> np.array:
+def to_euler(quaternions, order):
     """
     Convert a quaternion to an intrinsic euler representation with a specified order.
     Does not detect/solve gimbal lock.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     order : np.array[..., ['x'|'y'|'z', 'x'|'y'|'z', 'x'|'y'|'z']]
         order of the euler angles
         symmetric orders not supported (e.g., XYX).
 
     Returns
     -------
-    euler : np.array[..., 3]
+    euler : torch.Tensor or np.array[..., 3]
         euler angles in radians
     """
-
-    assert (
-        quaternions.shape[:-1] == order.shape[:-1]
-    ), "quaternions and order must have the same shape except for the last dimension"
-
-    aux = {
-        "x": 0,
-        "y": 1,
-        "z": 2,
-    }
-
-    angle_first = 2
-    angle_third = 0
-
-    i = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 2:3])[..., np.newaxis]
-    j = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 1:2])[..., np.newaxis]
-    k = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 0:1])[..., np.newaxis]
-
-    # check if permutation is even or odd
-    sign = (i - j) * (j - k) * (k - i) // 2
-
-    # euler angles
-    euler = np.empty(quaternions.shape[:-1] + (3,))
-
-    # permutate quaternion elements
-    a = quaternions[..., 0:1] - np.take_along_axis(quaternions, j + 1, axis=-1)
-    b = (
-        np.take_along_axis(quaternions, i + 1, axis=-1)
-        + np.take_along_axis(quaternions, k + 1, axis=-1) * sign
-    )
-    c = np.take_along_axis(quaternions, j + 1, axis=-1) + quaternions[..., 0:1]
-    d = np.take_along_axis(quaternions, k + 1, axis=-1) * sign - np.take_along_axis(
-        quaternions, i + 1, axis=-1
-    )
-
-    # compute second angle
-    euler[..., 1:2] = (2 * np.arctan2(np.hypot(c, d), np.hypot(a, b))) - (np.pi / 2)
-
-    # compute first and third angle
-    half_sum = np.arctan2(b, a)
-    half_diff = np.arctan2(d, c)
-    euler[..., angle_first : angle_first + 1] = half_sum - half_diff
-    euler[..., angle_third : angle_third + 1] = (half_sum + half_diff) * sign
-
-    # for i in range(3):
-    # if euler[..., i] < -np.pi:
-    #    euler[..., i] += 2 * np.pi
-    # elif euler[..., i] > np.pi:
-    #    euler[..., i] -= 2 * np.pi
-    euler = np.mod(euler, 2 * np.pi)
-
-    return euler
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.to_euler(quaternions, order)
+    else:
+        return _quat_np.to_euler(quaternions, order)
 
 
-def to_scaled_angle_axis(quaternions: np.array) -> np.array:
+def to_scaled_angle_axis(quaternions):
     """
     Quaternion to scaled axis angle representation.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    scaledaxis : np.array[..., [x,y,z]]
+    scaledaxis : torch.Tensor or np.array[..., [x,y,z]]
         axis [x,y,z] of rotation where magnitude is the angle of rotation
     """
-    angle, axis = to_angle_axis(quaternions)
-    return angle * axis
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.to_scaled_angle_axis(quaternions)
+    else:
+        return _quat_np.to_scaled_angle_axis(quaternions)
 
 
-def to_angle_axis(quaternions: np.array) -> np.array:
+def to_angle_axis(quaternions):
     """
-    Quaternion to scaled axis angle representation.
+    Quaternion to axis angle representation.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    angle: np.array[..., angle]
-    axis : np.array[..., [x,y,z]]
+    angle: torch.Tensor or np.array[..., angle]
+    axis : torch.Tensor or np.array[..., [x,y,z]]
         normalized axis [x,y,z] of rotation
     """
-    w = quaternions[..., 0]
-    xyz = quaternions[..., 1:]
-
-    angle = 2 * np.arccos(np.clip(w, -1.0, 1.0))
-    s = np.sqrt(np.clip(1.0 - w * w, 0.0, 1.0))
-
-    # Avoid division by zero when s is close to zero (identity quaternion)
-    axis = np.zeros_like(xyz)
-    mask = s > 1e-8
-    if mask.any():
-        axis[mask] = xyz[mask] / np.expand_dims(s[mask], axis=-1)
-
-    return angle[..., np.newaxis], axis
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.to_angle_axis(quaternions)
+    else:
+        return _quat_np.to_angle_axis(quaternions)
 
 
-def to_matrix(quaternions: np.array) -> np.array:
+def to_matrix(quaternions):
     """
     Convert rotations given as quaternions to rotation matrices.
-    Parameters
-    ----------
-        quaternions: np.array[..., [w,x,y,z]]
-    Returns
-    -------
-        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                     [r1.x, r1.y, r1.z],
-                                                     [r2.x, r2.y, r2.z]] where ri is row i.
-    """
-    qw = quaternions[..., 0]
-    qx = quaternions[..., 1]
-    qy = quaternions[..., 2]
-    qz = quaternions[..., 3]
-
-    x2 = qx + qx
-    y2 = qy + qy
-    z2 = qz + qz
-    xx = qx * x2
-    yy = qy * y2
-    wx = qw * x2
-    xy = qx * y2
-    yz = qy * z2
-    wy = qw * y2
-    xz = qx * z2
-    zz = qz * z2
-    wz = qw * z2
-
-    m = np.empty(quaternions.shape[:-1] + (3, 3))
-    m[..., 0, 0] = 1.0 - (yy + zz)
-    m[..., 0, 1] = xy - wz
-    m[..., 0, 2] = xz + wy
-    m[..., 1, 0] = xy + wz
-    m[..., 1, 1] = 1.0 - (xx + zz)
-    m[..., 1, 2] = yz - wx
-    m[..., 2, 0] = xz - wy
-    m[..., 2, 1] = yz + wx
-    m[..., 2, 2] = 1.0 - (xx + yy)
-
-    return m
-
-
-def mul_vec(q: np.array, v: np.array) -> np.array:
-    """
-    Multiply a vector by a quaternion
 
     Parameters
     ----------
-    q : np.array[..., [w,x,y,z]]
-    v : np.array[..., [x,y,z]]
+    quaternions: torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    v: np.array[..., [x,y,z]]
+    rotmats: torch.Tensor or np.array[..., 3, 3]
+        Matrix order: [[r0.x, r0.y, r0.z],
+                       [r1.x, r1.y, r1.z],
+                       [r2.x, r2.y, r2.z]] where ri is row i.
     """
-    t = 2.0 * _fast_cross(q[..., 1:], v)
-    return v + q[..., 0][..., np.newaxis] * t + _fast_cross(q[..., 1:], t)
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.to_matrix(quaternions)
+    else:
+        return _quat_np.to_matrix(quaternions)
 
 
-def mul(q0: np.array, q1: np.array) -> np.array:
+def mul_vec(q, v):
+    """
+    Multiply a vector by a quaternion.
+
+    Parameters
+    ----------
+    q : torch.Tensor or np.array[..., [w,x,y,z]]
+    v : torch.Tensor or np.array[..., [x,y,z]]
+
+    Returns
+    -------
+    v: torch.Tensor or np.array[..., [x,y,z]]
+    """
+    if _TorchTensor is not None and isinstance(q, _TorchTensor):
+        return _quat_torch.mul_vec(q, v)
+    else:
+        return _quat_np.mul_vec(q, v)
+
+
+def mul(q0, q1):
     """
     Multiply two quaternions.
 
     Parameters
     ----------
-    q0 : np.array[..., [w,x,y,z]]
-    q1 : np.array[..., [w,x,y,z]]
+    q0 : torch.Tensor or np.array[..., [w,x,y,z]]
+    q1 : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quat : np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    w0, x0, y0, z0 = q0[..., 0:1], q0[..., 1:2], q0[..., 2:3], q0[..., 3:4]
-    w1, x1, y1, z1 = q1[..., 0:1], q1[..., 1:2], q1[..., 2:3], q1[..., 3:4]
-    # (w0,v0)(w1,v1) = (w0w1 - v0·v1, w0v1 + w1v0 + v0 x v1)
-    return np.concatenate(
-        (
-            w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1,  # w
-            w0 * x1 + w1 * x0 + y0 * z1 - z0 * y1,  # x
-            w0 * y1 + w1 * y0 + z0 * x1 - x0 * z1,  # y
-            w0 * z1 + w1 * z0 + x0 * y1 - y0 * x1,  # z
-        ),
-        axis=-1,
-    )
+    if _TorchTensor is not None and isinstance(q0, _TorchTensor):
+        return _quat_torch.mul(q0, q1)
+    else:
+        return _quat_np.mul(q0, q1)
 
 
-def length(quaternions: np.array) -> np.array:
+def length(quaternions):
     """
     Get the length or magnitude of the quaternions.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    length : np.array[...]
+    length : torch.Tensor or np.array[...]
     """
-    return np.linalg.norm(quaternions, axis=-1)
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.length(quaternions)
+    else:
+        return _quat_np.length(quaternions)
 
 
-def inverse(quaternions: np.array) -> np.array:
+def inverse(quaternions):
     """
     Inverse of a quaternion.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    # for a unit quaternion the conjugate is the inverse
-    # q^-1 = [q0, -q1, -q2, -q3]
-    return conjugate(quaternions)
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.inverse(quaternions)
+    else:
+        return _quat_np.inverse(quaternions)
 
 
-def conjugate(quaternions: np.array) -> np.array:
+def conjugate(quaternions):
     """
     Compute the conjugate of a quaternion.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    return np.concatenate((quaternions[..., 0:1], -quaternions[..., 1:]), axis=-1)
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.conjugate(quaternions)
+    else:
+        return _quat_np.conjugate(quaternions)
 
 
-def normalize(quaternions: np.array, eps: float = 1e-8) -> np.array:
+def normalize(quaternions, eps=1e-8):
     """
-    Convert all quaternions to unit quatenrions.
+    Convert all quaternions to unit quaternions.
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
+    eps : float, optional
+        Small value to avoid division by zero. Default is 1e-8.
 
     Returns
     -------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    return quaternions / (length(quaternions)[..., np.newaxis] + eps)
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.normalize(quaternions, eps)
+    else:
+        return _quat_np.normalize(quaternions, eps)
 
 
-def unroll(quaternions: np.array, axis: int) -> np.array:
+def unroll(quaternions, dim):
     """
     Avoid the quaternion 'double cover' problem by picking the cover
     of the first quaternion, and then removing sudden switches
@@ -440,145 +330,130 @@ def unroll(quaternions: np.array, axis: int) -> np.array:
 
     Parameters
     ----------
-    quaternions : np.array[..., [w,x,y,z]]
-    axis : int
-        unroll axis (e.g., frames axis)
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
+    dim : int
+        unroll dimension (e.g., frames dimension)
 
     Returns
     -------
-    quaternions : np.array[..., [w,x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    r = quaternions.swapaxes(0, axis)
-    # start with the second quaternion since
-    # we keep the cover of the first one
-    for i in range(1, r.shape[0]):
-        # distance (dot product) between the previous and current quaternion
-        d0 = np.sum(r[i] * r[i - 1], axis=-1)
-        # distance (dot product) between the previous and flipped current quaternion
-        d1 = np.sum(-r[i] * r[i - 1], axis=-1)
-        # if the distance with the flipped quaternion is smaller, use it
-        r[i][d0 < d1] = -r[i][d0 < d1]
-    r = r.swapaxes(0, axis)
-    return r
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.unroll(quaternions, dim)
+    else:
+        return _quat_np.unroll(quaternions, dim)
 
 
-def slerp(q0: np.array, q1: np.array, t: float | np.array, shortest: bool = True) -> np.array:
+def slerp(q0, q1, t, shortest=True):
     """
     Perform spherical linear interpolation (SLERP) between two unit quaternions.
 
     Parameters
     ----------
-    q0 : np.array[..., [w,x,y,z]]
-    q1 : np.array[..., [w,x,y,z]]
-    t : float or np.array[..., [t]]
+    q0 : torch.Tensor or np.array[..., [w,x,y,z]]
+    q1 : torch.Tensor or np.array[..., [w,x,y,z]]
+    t : float or torch.Tensor or np.array[..., [t]]
         Interpolation parameter between 0 and 1. At t=0, returns q0 and at t=1, returns q1.
-    shorthest : bool
-        Ensure the shorthest path between quaternions.
+    shortest : bool, optional
+        Ensure the shortest path between quaternions. Default is True.
 
     Returns
     -------
-    quat : np.array[..., [w,x,y,z]]
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
     """
-    # Compute the cosine of the angle between the two vectors.
-    dot = np.sum(q0 * q1, axis=-1, keepdims=True)
-
-    # If the dot product is negative, the quaternions
-    # have opposite handed-ness and slerp won't take
-    # the shorter path. Fix by reversing one quaternion.
-    q1 = np.where(shortest and dot < 0, -q1, q1)
-    dot = np.where(shortest and dot < 0, -dot, dot)
-
-    # Clamp to prevent instability at near 180° angle
-    dot = np.clip(dot, -1, 1)
-
-    # Compute the quaternion of the angle between the quaternions
-    theta_0 = np.arccos(dot)  # theta_0 = angle between input vectors
-    theta = theta_0 * t  # theta = angle between q0 vector and result
-
-    q2 = q1 - q0 * dot
-    q2 /= np.linalg.norm(q2 + 0.000001, axis=-1, keepdims=True)  # {q0, q2} is now an orthonormal basis
-
-    return np.cos(theta) * q0 + np.sin(theta) * q2
+    if _TorchTensor is not None and isinstance(q0, _TorchTensor):
+        return _quat_torch.slerp(q0, q1, t, shortest)
+    else:
+        return _quat_np.slerp(q0, q1, t, shortest)
 
 
-def from_to(v1: np.ndarray, v2: np.ndarray, normalize_input: bool = True) -> np.ndarray:
+def weighted_slerp(quaternions, weights, shortest=True):
+    """
+    Perform weighted spherical linear interpolation (SLERP) across multiple quaternions.
+    Uses iterative weighted SLERP to properly blend quaternions based on their weights.
+
+    Parameters
+    ----------
+    quaternions : torch.Tensor or np.array[num_items, ..., [w,x,y,z]]
+        Quaternions to blend. First dimension is the items to blend.
+        For batch processing with different weights, call this function in a loop.
+    weights : torch.Tensor or np.array[num_items]
+        Weights for each quaternion. Must sum to approximately 1.0 for meaningful results.
+    shortest : bool, optional
+        Ensure the shortest path between quaternions. Default is True.
+
+    Returns
+    -------
+    quat : torch.Tensor or np.array[..., [w,x,y,z]]
+        Weighted blend of input quaternions
+
+    Notes
+    -----
+    This function performs iterative weighted SLERP:
+    1. Start with first quaternion
+    2. For each subsequent quaternion i:
+       - Compute t_i = weight_i / (accumulated_weight + weight_i)
+       - SLERP between accumulated result and quaternion i with parameter t_i
+       - Update accumulated_weight += weight_i
+
+    This approach ensures proper geodesic blending on the quaternion manifold.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pymotion.rotations.quat as quat
+    >>>
+    >>> # Define 3 quaternions (identity, 90° around Z, 180° around Z)
+    >>> quaternions = np.array([
+    ...     [1.0, 0.0, 0.0, 0.0],  # identity
+    ...     [0.707, 0.0, 0.0, 0.707],  # 90° Z
+    ...     [0.0, 0.0, 0.0, 1.0],  # 180° Z
+    ... ])
+    >>>
+    >>> # Single weight vector
+    >>> weights = np.array([0.33, 0.33, 0.34])
+    >>> result = quat.weighted_slerp(quaternions, weights)
+    >>>
+    >>> # Batch processing with different weights - call in a loop
+    >>> weights_batch = np.array([
+    ...     [1.0, 0.0, 0.0],  # Only first quaternion
+    ...     [0.0, 1.0, 0.0],  # Only second quaternion
+    ...     [0.5, 0.5, 0.0],  # Blend first two
+    ... ])
+    >>> results = np.stack([
+    ...     quat.weighted_slerp(quaternions, w) for w in weights_batch
+    ... ])
+    """
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.weighted_slerp(quaternions, weights, shortest)
+    else:
+        return _quat_np.weighted_slerp(quaternions, weights, shortest)
+
+
+def from_to(v1, v2, normalize_input=True):
     """
     Calculate the quaternion that rotates direction v1 to direction v2.
     When v1 and v2 are parallel, the result is the identity quaternion.
 
     Parameters
     ----------
-    v1, v2 : np.array[..., [x,y,z]]
+    v1, v2 : torch.Tensor or np.array[..., [x,y,z]]
         Input vectors representing directions.
-    normalize_input : bool
-        Whether to normalize the input vectors.
+    normalize_input : bool, optional
+        Whether to normalize the input vectors. Default is True.
 
     Returns
     -------
-    rot : np.array[..., [w,x,y,z]]
+    rot : torch.Tensor or np.array[..., [w,x,y,z]]
         Quaternion representing the rotation.
     """
-    assert v1.shape[-1] == 3 and v2.shape[-1] == 3, "Input vectors must have shape [..., 3]"
-    assert v1.shape == v2.shape, "Input vectors must have the same shape"
-
-    if normalize_input:
-        v1_norm = vec.normalize(v1)
-        v2_norm = vec.normalize(v2)
+    if _TorchTensor is not None and isinstance(v1, _TorchTensor):
+        return _quat_torch.from_to(v1, v2, normalize_input)
     else:
-        v1_norm = v1
-        v2_norm = v2
-
-    if v1.ndim == 1:
-        v1_norm = v1_norm[np.newaxis, :]
-        v2_norm = v2_norm[np.newaxis, :]
-
-    # Calculate cross product and dot product
-    cross = np.cross(v1_norm, v2_norm)
-    dot = np.sum(v1_norm * v2_norm, axis=-1, keepdims=True)
-
-    # Handle general case
-    axis_rot = normalize(cross)
-    w = np.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
-    s = np.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
-    rot = np.concatenate([w, axis_rot * s], axis=-1)
-
-    # Handle parallel vectors (dot ≈ 1)
-    parallel = np.isclose(dot, 1.0)
-    rot[parallel[..., 0]] = [1.0, 0.0, 0.0, 0.0]
-
-    # Handle anti-parallel vectors (dot ≈ -1)
-    anti_parallel_mask = np.isclose(dot, -1.0)[..., 0]
-
-    if np.any(anti_parallel_mask):  # Check if any anti-parallel vectors exist
-        v1_anti_parallel = v1_norm[anti_parallel_mask]  # Extract anti-parallel v1 vectors
-
-        # Vectorized orthogonal vector selection
-        orthogonal_anti_parallel = np.empty_like(v1_anti_parallel)  # Initialize with correct shape
-        condition_mask = np.isclose(np.abs(v1_anti_parallel[..., 0]), 1.0)  # Boolean mask
-
-        orthogonal_anti_parallel[condition_mask] = np.array([0.0, 1.0, 0.0])  # Assign for True condition
-        orthogonal_anti_parallel[~condition_mask] = np.array([1.0, 0.0, 0.0])  # Assign for False condition
-
-        # Vectorized axis of rotation calculation
-        axis_rot_anti_parallel = normalize(np.cross(v1_anti_parallel, orthogonal_anti_parallel))
-
-        # Vectorized quaternion construction for anti-parallel case
-        rot_correction_anti_parallel = np.concatenate(
-            [np.zeros_like(axis_rot_anti_parallel[..., :1]), axis_rot_anti_parallel], axis=-1
-        )
-
-        # Vectorized assignment of corrections
-        rot[anti_parallel_mask] = rot_correction_anti_parallel
-
-    if v1.ndim == 1:
-        rot = rot[0]
-
-    return rot
+        return _quat_np.from_to(v1, v2, normalize_input)
 
 
-def from_to_axis(
-    v1: np.ndarray, v2: np.ndarray, rot_axis: np.ndarray, normalize_input: bool = True
-) -> np.ndarray:
+def from_to_axis(v1, v2, rot_axis, normalize_input=True):
     """
     Calculate the quaternion that rotates direction v1 to direction v2.
     The rotation axis is fixed to the provided axis.
@@ -586,89 +461,136 @@ def from_to_axis(
 
     Parameters
     ----------
-    v1, v2 : np.array[..., [x,y,z]]
+    v1, v2 : torch.Tensor or np.array[..., [x,y,z]]
         Input vectors representing directions.
-    axis : np.array[..., [x,y,z]]
+    rot_axis : torch.Tensor or np.array[..., [x,y,z]]
         Fixed rotation axis.
-    normalize_input : bool
-        Whether to normalize the input vectors.
+    normalize_input : bool, optional
+        Whether to normalize the input vectors. Default is True.
 
     Returns
     -------
-    rot : np.array[..., [w,x,y,z]]
+    rot : torch.Tensor or np.array[..., [w,x,y,z]]
         Quaternion representing the rotation.
     """
-    assert v1.shape[-1] == 3 and v2.shape[-1] == 3, "Input vectors must have shape [..., 3]"
-    assert v1.shape == v2.shape, "Input vectors must have the same shape"
-    assert v1.shape == rot_axis.shape, "Input vectors and rotation axis must have the same shape"
-
-    if rot_axis.ndim == 1:
-        rot_axis = rot_axis[np.newaxis, :]
-
-    if normalize_input:
-        v1_norm = vec.normalize(v1)
-        v2_norm = vec.normalize(v2)
+    if _TorchTensor is not None and isinstance(v1, _TorchTensor):
+        return _quat_torch.from_to_axis(v1, v2, rot_axis, normalize_input)
     else:
-        v1_norm = v1
-        v2_norm = v2
-
-    if v1.ndim == 1:
-        v1_norm = v1_norm[np.newaxis, :]
-        v2_norm = v2_norm[np.newaxis, :]
-
-    # Calculate cross product and dot product
-    cross = np.cross(v1_norm, v2_norm)
-    dot = np.sum(v1_norm * v2_norm, axis=-1, keepdims=True)
-
-    # Handle general case
-    w = np.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
-    s = np.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
-    # Adjust sign of s based on cross product and rot_axis
-    cross_dot_axis = np.sum(cross * rot_axis, axis=-1, keepdims=True)
-    s *= np.sign(cross_dot_axis)  # Correct sign based on alignment
-    # Combine w and s to form quaternion
-    rot = np.concatenate([w, rot_axis * s], axis=-1)
-
-    # Handle parallel vectors (dot ≈ 1)
-    parallel = np.isclose(dot, 1.0)
-    rot[parallel[..., 0]] = [1.0, 0.0, 0.0, 0.0]
-
-    # Handle anti-parallel vectors (dot ≈ -1)
-    anti_parallel = np.isclose(dot, -1.0)
-    anti_parallel_rotmask = np.tile(anti_parallel, (1,) * (rot.ndim - 1) + (4,))
-    anti_parallel_rotaxismask = np.tile(anti_parallel, (1,) * (rot_axis.ndim - 1) + (3,))
-    rots_anti_parallel = rot[anti_parallel_rotmask]
-    rots_anti_parallel[::4] = 0
-    rots_anti_parallel[[False, True, True, True] * (len(rots_anti_parallel) // 4)] = rot_axis[
-        anti_parallel_rotaxismask
-    ]
-    rot[anti_parallel_rotmask] = rots_anti_parallel
-
-    if v1.ndim == 1:
-        rot = rot[0]
-
-    return rot
+        return _quat_np.from_to_axis(v1, v2, rot_axis, normalize_input)
 
 
-def _fast_cross(a: np.array, b: np.array) -> np.array:
+def canonicalize(quaternions):
     """
-    Fast cross of two vectors
+    Convert quaternions to canonical form where w >= 0.
+
+    This resolves the quaternion double-cover problem by ensuring all quaternions
+    use the same hemisphere. This is important before operations like scaling
+    the rotation angle, as it ensures the shortest rotation path is used.
+
+    The PyTorch implementation is fully differentiable.
 
     Parameters
     ----------
-    a : np.array[..., [x,y,z]]
-    b : np.array[..., [x,y,z]]
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    np.array[..., [x,y,z]]
-    """
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
+        Quaternions with w >= 0 (same rotation, canonical representation)
 
-    return np.concatenate(
-        [
-            a[..., 1:2] * b[..., 2:3] - a[..., 2:3] * b[..., 1:2],
-            a[..., 2:3] * b[..., 0:1] - a[..., 0:1] * b[..., 2:3],
-            a[..., 0:1] * b[..., 1:2] - a[..., 1:2] * b[..., 0:1],
-        ],
-        axis=-1,
-    )
+    Notes
+    -----
+    A quaternion q and -q represent the same rotation. However, when converting
+    to angle-axis representation, a quaternion with w < 0 will produce an angle
+    > 180°, which represents the "long way around". By ensuring w >= 0, we
+    guarantee the angle will be <= 180° (the shortest rotation path).
+
+    Examples
+    --------
+    >>> q = np.array([[-0.707, 0.0, 0.707, 0.0]])  # w < 0
+    >>> q_canonical = canonicalize(q)
+    >>> print(q_canonical)  # [0.707, 0.0, -0.707, 0.0], same rotation but w >= 0
+    """
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.canonicalize(quaternions)
+    else:
+        return _quat_np.canonicalize(quaternions)
+
+
+def scale(quaternions, factor):
+    """
+    Scale quaternion rotations by a factor.
+
+    This function scales the rotation angle of quaternions while preserving
+    the rotation axis. A factor of 0.5 gives half the rotation, 2.0 doubles it, etc.
+
+    The function automatically handles the quaternion double-cover problem by
+    canonicalizing quaternions before scaling, ensuring the shortest rotation
+    path is always used.
+
+    The PyTorch implementation is fully differentiable.
+
+    Parameters
+    ----------
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
+        Input quaternions to scale.
+    factor : float, torch.Tensor, or np.array
+        Scale factor for the rotation angle. Can be:
+        - A scalar (applies same scale to all quaternions)
+        - A tensor/array broadcastable to quaternions shape (for per-element scaling)
+
+    Returns
+    -------
+    quaternions : torch.Tensor or np.array[..., [w,x,y,z]]
+        Scaled quaternions.
+
+    Notes
+    -----
+    The scaling is performed in angle-axis space:
+    1. Canonicalize quaternions (ensure w >= 0 for shortest path)
+    2. Convert to scaled angle-axis representation
+    3. Multiply the angle by the scale factor
+    4. Convert back to quaternion
+
+    Examples
+    --------
+    >>> q = np.array([[0.707, 0.0, 0.707, 0.0]])  # 90° rotation around Y
+    >>> q_half = scale(q, 0.5)  # 45° rotation around Y
+    >>> q_double = scale(q, 2.0)  # 180° rotation around Y
+
+    >>> # Per-joint scaling
+    >>> q = np.random.randn(10, 22, 4)  # 10 frames, 22 joints
+    >>> q = normalize(q)
+    >>> joint_scales = np.random.rand(22, 1)  # Different scale per joint
+    >>> q_scaled = scale(q, joint_scales)
+    """
+    if _TorchTensor is not None and isinstance(quaternions, _TorchTensor):
+        return _quat_torch.scale(quaternions, factor)
+    else:
+        return _quat_np.scale(quaternions, factor)
+
+
+# Expose public API
+__all__ = [
+    "from_scaled_angle_axis",
+    "from_angle_axis",
+    "from_euler",
+    "from_matrix",
+    "to_euler",
+    "to_scaled_angle_axis",
+    "to_angle_axis",
+    "to_matrix",
+    "mul_vec",
+    "mul",
+    "length",
+    "inverse",
+    "conjugate",
+    "normalize",
+    "unroll",
+    "slerp",
+    "weighted_slerp",
+    "from_to",
+    "from_to_axis",
+    "canonicalize",
+    "scale",
+]

--- a/pymotion/rotations/quat_np.py
+++ b/pymotion/rotations/quat_np.py
@@ -1,34 +1,33 @@
-# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 from __future__ import annotations
-import torch
-import torch.nn.functional as F
+
 import numpy as np
-import pymotion.ops.vector_torch as vec
+import pymotion.ops.vector_np as vec
 
 
-def from_scaled_angle_axis(scaledaxis: torch.Tensor) -> torch.Tensor:
+def from_scaled_angle_axis(scaledaxis: np.array) -> np.array:
     """
     Create a quaternion from an scaled angle-axis representation.
 
     Parameters
     ----------
-    scaledaxis : torch.Tensor[..., [x,y,z]]
+    scaledaxis : np.array[..., [x,y,z]]
         axis [x,y,z] of rotation where magnitude is the angle of rotation
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
     """
-    angle = torch.linalg.norm(scaledaxis, dim=-1, keepdim=True)
+    angle = np.linalg.norm(scaledaxis, axis=-1)[..., np.newaxis]
 
     # Handle zero angle case: return identity quaternion [1, 0, 0, 0]
     # Use a small epsilon to avoid division by zero
     eps = 1e-8
     is_zero = angle < eps
 
-    # Safe division: use angle + eps where angle is zero to avoid NaN
-    safe_angle = torch.where(is_zero, torch.ones_like(angle), angle)
+    # Safe division: use 1.0 where angle is zero to avoid NaN
+    safe_angle = np.where(is_zero, np.ones_like(angle), angle)
     axis = scaledaxis / safe_angle
 
     # Compute quaternion from angle-axis
@@ -37,32 +36,32 @@ def from_scaled_angle_axis(scaledaxis: torch.Tensor) -> torch.Tensor:
     return result
 
 
-def from_angle_axis(angle: torch.Tensor, axis: torch.Tensor) -> torch.Tensor:
+def from_angle_axis(angle: np.array, axis: np.array) -> np.array:
     """
     Create a quaternion from an angle-axis representation.
 
     Parameters
     ----------
-    angle : torch.Tensor[..., angle] in radians.
-    axis : torch.Tensor[..., [x,y,z]]
+    angle : np.array[..., angle] in radians.
+    axis : np.array[..., [x,y,z]]
         normalized axis [x,y,z] of rotation
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
     """
-    c = torch.cos(angle / 2.0)
-    s = torch.sin(angle / 2.0)
-    return torch.cat((c, s * axis), dim=-1)
+    c = np.cos(angle / 2.0)
+    s = np.sin(angle / 2.0)
+    return np.concatenate((c, s * axis), axis=-1)
 
 
-def from_euler(euler: torch.Tensor, order: np.array) -> torch.Tensor:
+def from_euler(euler: np.array, order: np.array) -> np.array:
     """
     Create a quaternion from an euler representation with a specified order.
 
     Parameters
     ----------
-    euler : torch.Tensor[..., [e0, e1, e2]]
+    euler : np.array[..., [e0, e1, e2]]
         euler angles in radians
     order : np.array[..., ['x'|'y'|'z', 'x'|'y'|'z', 'x'|'y'|'z']]
         order of the euler angles
@@ -70,7 +69,7 @@ def from_euler(euler: torch.Tensor, order: np.array) -> torch.Tensor:
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
     """
 
     assert (
@@ -82,34 +81,35 @@ def from_euler(euler: torch.Tensor, order: np.array) -> torch.Tensor:
         "y": np.array([0, 1, 0]),
         "z": np.array([0, 0, 1]),
     }
+
     q0 = from_angle_axis(
         euler[..., 0:1],
-        torch.from_numpy(np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 0:1])).to(euler.device),
+        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 0:1]),
     )
     q1 = from_angle_axis(
         euler[..., 1:2],
-        torch.from_numpy(np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 1:2])).to(euler.device),
+        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 1:2]),
     )
     q2 = from_angle_axis(
         euler[..., 2:3],
-        torch.from_numpy(np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 2:3])).to(euler.device),
+        np.apply_along_axis(lambda x: axis[x.item()], -1, order[..., 2:3]),
     )
     return mul(q0, mul(q1, q2))
 
 
-def from_matrix(rotmats: torch.Tensor) -> torch.Tensor:
+def from_matrix(rotmats: np.array) -> np.array:
     """
     Convert rotation matrices to quaternions.
 
     Parameters
     ----------
-        rotmats: torch.Tensor[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                         [r1.x, r1.y, r1.z],
-                                                         [r2.x, r2.y, r2.z]] where ri is row i.
+        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
+                                                     [r1.x, r1.y, r1.z],
+                                                     [r2.x, r2.y, r2.z]] where ri is row i.
 
     Returns
     -------
-        quat torch.Tensor[..., [w,x,y,z]]
+        quat np.array[..., [w,x,y,z]]
     """
     # Separate components
     r0c0 = rotmats[..., 0, 0]
@@ -123,69 +123,69 @@ def from_matrix(rotmats: torch.Tensor) -> torch.Tensor:
     r2c2 = rotmats[..., 2, 2]
 
     return normalize(
-        torch.where(
-            (r2c2 < 0.0).unsqueeze(-1),
-            torch.where(
-                (r0c0 > r1c1).unsqueeze(-1),
-                torch.cat(
+        np.where(
+            (r2c2 < 0.0)[..., np.newaxis],
+            np.where(
+                (r0c0 > r1c1)[..., np.newaxis],
+                np.concatenate(
                     [
-                        (r2c1 - r1c2).unsqueeze(-1),
-                        (1.0 + r0c0 - r1c1 - r2c2).unsqueeze(-1),
-                        (r1c0 + r0c1).unsqueeze(-1),
-                        (r0c2 + r2c0).unsqueeze(-1),
+                        (r2c1 - r1c2)[..., np.newaxis],
+                        (1.0 + r0c0 - r1c1 - r2c2)[..., np.newaxis],
+                        (r1c0 + r0c1)[..., np.newaxis],
+                        (r0c2 + r2c0)[..., np.newaxis],
                     ],
-                    dim=-1,
+                    axis=-1,
                 ),
-                torch.cat(
+                np.concatenate(
                     [
-                        (r0c2 - r2c0).unsqueeze(-1),
-                        (r1c0 + r0c1).unsqueeze(-1),
-                        (1.0 - r0c0 + r1c1 - r2c2).unsqueeze(-1),
-                        (r2c1 + r1c2).unsqueeze(-1),
+                        (r0c2 - r2c0)[..., np.newaxis],
+                        (r1c0 + r0c1)[..., np.newaxis],
+                        (1.0 - r0c0 + r1c1 - r2c2)[..., np.newaxis],
+                        (r2c1 + r1c2)[..., np.newaxis],
                     ],
-                    dim=-1,
+                    axis=-1,
                 ),
             ),
-            torch.where(
-                (r0c0 < -r1c1).unsqueeze(-1),
-                torch.cat(
+            np.where(
+                (r0c0 < -r1c1)[..., np.newaxis],
+                np.concatenate(
                     [
-                        (r1c0 - r0c1).unsqueeze(-1),
-                        (r0c2 + r2c0).unsqueeze(-1),
-                        (r2c1 + r1c2).unsqueeze(-1),
-                        (1.0 - r0c0 - r1c1 + r2c2).unsqueeze(-1),
+                        (r1c0 - r0c1)[..., np.newaxis],
+                        (r0c2 + r2c0)[..., np.newaxis],
+                        (r2c1 + r1c2)[..., np.newaxis],
+                        (1.0 - r0c0 - r1c1 + r2c2)[..., np.newaxis],
                     ],
-                    dim=-1,
+                    axis=-1,
                 ),
-                torch.cat(
+                np.concatenate(
                     [
-                        (1.0 + r0c0 + r1c1 + r2c2).unsqueeze(-1),
-                        (r2c1 - r1c2).unsqueeze(-1),
-                        (r0c2 - r2c0).unsqueeze(-1),
-                        (r1c0 - r0c1).unsqueeze(-1),
+                        (1.0 + r0c0 + r1c1 + r2c2)[..., np.newaxis],
+                        (r2c1 - r1c2)[..., np.newaxis],
+                        (r0c2 - r2c0)[..., np.newaxis],
+                        (r1c0 - r0c1)[..., np.newaxis],
                     ],
-                    dim=-1,
+                    axis=-1,
                 ),
             ),
         )
     )
 
 
-def to_euler(quaternions: torch.Tensor, order: np.array) -> torch.Tensor:
+def to_euler(quaternions: np.array, order: np.array) -> np.array:
     """
     Convert a quaternion to an intrinsic euler representation with a specified order.
     Does not detect/solve gimbal lock.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
     order : np.array[..., ['x'|'y'|'z', 'x'|'y'|'z', 'x'|'y'|'z']]
         order of the euler angles
         symmetric orders not supported (e.g., XYX).
 
     Returns
     -------
-    euler : torch.Tensor[..., 3]
+    euler : np.array[..., 3]
         euler angles in radians
     """
 
@@ -202,45 +202,39 @@ def to_euler(quaternions: torch.Tensor, order: np.array) -> torch.Tensor:
     angle_first = 2
     angle_third = 0
 
-    i = (
-        torch.from_numpy(np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 2:3])[..., np.newaxis])
-        .to(quaternions.device)
-        .type(torch.long)
-    )
-    j = (
-        torch.from_numpy(np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 1:2])[..., np.newaxis])
-        .to(quaternions.device)
-        .type(torch.long)
-    )
-    k = (
-        torch.from_numpy(np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 0:1])[..., np.newaxis])
-        .to(quaternions.device)
-        .type(torch.long)
-    )
+    i = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 2:3])[
+        ..., np.newaxis
+    ]
+    j = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 1:2])[
+        ..., np.newaxis
+    ]
+    k = np.apply_along_axis(lambda x: aux[x.item()], -1, order[..., 0:1])[
+        ..., np.newaxis
+    ]
 
     # check if permutation is even or odd
     sign = (i - j) * (j - k) * (k - i) // 2
 
     # euler angles
-    euler = torch.empty(quaternions.shape[:-1] + (3,), device=quaternions.device)
+    euler = np.empty(quaternions.shape[:-1] + (3,))
 
     # permutate quaternion elements
-    a = quaternions[..., 0:1] - torch.take_along_dim(quaternions, j + 1, dim=-1)
+    a = quaternions[..., 0:1] - np.take_along_axis(quaternions, j + 1, axis=-1)
     b = (
-        torch.take_along_dim(quaternions, i + 1, dim=-1)
-        + torch.take_along_dim(quaternions, k + 1, dim=-1) * sign
+        np.take_along_axis(quaternions, i + 1, axis=-1)
+        + np.take_along_axis(quaternions, k + 1, axis=-1) * sign
     )
-    c = torch.take_along_dim(quaternions, j + 1, dim=-1) + quaternions[..., 0:1]
-    d = torch.take_along_dim(quaternions, k + 1, dim=-1) * sign - torch.take_along_dim(
-        quaternions, i + 1, dim=-1
+    c = np.take_along_axis(quaternions, j + 1, axis=-1) + quaternions[..., 0:1]
+    d = np.take_along_axis(quaternions, k + 1, axis=-1) * sign - np.take_along_axis(
+        quaternions, i + 1, axis=-1
     )
 
     # compute second angle
-    euler[..., 1:2] = (2 * torch.arctan2(torch.hypot(c, d), torch.hypot(a, b))) - (torch.pi / 2)
+    euler[..., 1:2] = (2 * np.arctan2(np.hypot(c, d), np.hypot(a, b))) - (np.pi / 2)
 
     # compute first and third angle
-    half_sum = torch.arctan2(b, a)
-    half_diff = torch.arctan2(d, c)
+    half_sum = np.arctan2(b, a)
+    half_diff = np.arctan2(d, c)
     euler[..., angle_first : angle_first + 1] = half_sum - half_diff
     euler[..., angle_third : angle_third + 1] = (half_sum + half_diff) * sign
 
@@ -249,75 +243,73 @@ def to_euler(quaternions: torch.Tensor, order: np.array) -> torch.Tensor:
     #    euler[..., i] += 2 * np.pi
     # elif euler[..., i] > np.pi:
     #    euler[..., i] -= 2 * np.pi
-    euler = torch.remainder(euler, 2 * torch.pi)
+    euler = np.mod(euler, 2 * np.pi)
 
     return euler
 
 
-def to_scaled_angle_axis(quaternions: torch.Tensor) -> torch.Tensor:
+def to_scaled_angle_axis(quaternions: np.array) -> np.array:
     """
     Quaternion to scaled axis angle representation.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    scaledaxis : torch.Tensor[..., [x,y,z]]
+    scaledaxis : np.array[..., [x,y,z]]
         axis [x,y,z] of rotation where magnitude is the angle of rotation
     """
     angle, axis = to_angle_axis(quaternions)
     return angle * axis
 
 
-def to_angle_axis(quaternions: torch.Tensor) -> torch.Tensor:
+def to_angle_axis(quaternions: np.array) -> np.array:
     """
     Quaternion to scaled axis angle representation.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    angle: torch.Tensor[..., angle]
-    axis : torch.Tensor[..., [x,y,z]]
+    angle: np.array[..., angle]
+    axis : np.array[..., [x,y,z]]
         normalized axis [x,y,z] of rotation
     """
     w = quaternions[..., 0]
     xyz = quaternions[..., 1:]
 
-    # Clamp w to avoid numerical issues with arccos
-    w_clamped = torch.clamp(w, -1.0 + 1e-7, 1.0 - 1e-7)
-    angle = 2 * torch.arccos(w_clamped)
+    angle = 2 * np.arccos(np.clip(w, -1.0, 1.0))
+    s = np.sqrt(np.clip(1.0 - w * w, 0.0, 1.0))
 
-    # s = sin(angle/2) = sqrt(1 - w^2)
-    # Add small epsilon to avoid division by zero while maintaining gradient flow
-    s = torch.sqrt(torch.clamp(1.0 - w * w, min=1e-12))
+    # Avoid division by zero when s is close to zero (identity quaternion)
+    axis = np.zeros_like(xyz)
+    mask = s > 1e-8
+    if mask.any():
+        axis[mask] = xyz[mask] / np.expand_dims(s[mask], axis=-1)
 
-    # Use safe division instead of masking (maintains gradient flow)
-    # When s is very small, xyz should also be very small for a valid quaternion
-    axis = xyz / (s.unsqueeze(-1) + 1e-8)
-
-    return angle.unsqueeze(-1), axis
+    return angle[..., np.newaxis], axis
 
 
-def to_matrix(quaternions: torch.Tensor) -> torch.Tensor:
+def to_matrix(quaternions: np.array) -> np.array:
     """
     Convert rotations given as quaternions to rotation matrices.
-
     Parameters
     ----------
-        quaternions: torch.Tensor[..., [w,x,y,z]]
-
+        quaternions: np.array[..., [w,x,y,z]]
     Returns
     -------
-        rotmats: torch.Tensor[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
-                                                         [r1.x, r1.y, r1.z],
-                                                         [r2.x, r2.y, r2.z]] where ri is row i.
+        rotmats: np.array[..., 3, 3]. Matrix order: [[r0.x, r0.y, r0.z],
+                                                     [r1.x, r1.y, r1.z],
+                                                     [r2.x, r2.y, r2.z]] where ri is row i.
     """
-    qw, qx, qy, qz = torch.unbind(quaternions, -1)
+    qw = quaternions[..., 0]
+    qx = quaternions[..., 1]
+    qy = quaternions[..., 2]
+    qz = quaternions[..., 3]
 
     x2 = qx + qx
     y2 = qy + qy
@@ -332,7 +324,7 @@ def to_matrix(quaternions: torch.Tensor) -> torch.Tensor:
     zz = qz * z2
     wz = qw * z2
 
-    m = torch.empty(quaternions.shape[:-1] + (3, 3), device=quaternions.device)
+    m = np.empty(quaternions.shape[:-1] + (3, 3))
     m[..., 0, 0] = 1.0 - (yy + zz)
     m[..., 0, 1] = xy - wz
     m[..., 0, 2] = xz + wy
@@ -346,116 +338,113 @@ def to_matrix(quaternions: torch.Tensor) -> torch.Tensor:
     return m
 
 
-def mul_vec(q: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+def mul_vec(q: np.array, v: np.array) -> np.array:
     """
     Multiply a vector by a quaternion
 
     Parameters
     ----------
-    q : torch.Tensor[..., [w,x,y,z]]
-    v : torch.Tensor[..., [x,y,z]]
+    q : np.array[..., [w,x,y,z]]
+    v : np.array[..., [x,y,z]]
 
     Returns
     -------
-    v: torch.Tensor[..., [x,y,z]]
+    v: np.array[..., [x,y,z]]
     """
     t = 2.0 * _fast_cross(q[..., 1:], v)
-    return v + q[..., 0].unsqueeze(-1) * t + _fast_cross(q[..., 1:], t)
+    return v + q[..., 0][..., np.newaxis] * t + _fast_cross(q[..., 1:], t)
 
 
-def mul(q0: torch.Tensor, q1: torch.Tensor) -> torch.Tensor:
+def mul(q0: np.array, q1: np.array) -> np.array:
     """
     Multiply two quaternions.
 
     Parameters
     ----------
-    q0 : torch.Tensor[..., [w,x,y,z]]
-    q1 : torch.Tensor[..., [w,x,y,z]]
+    q0 : np.array[..., [w,x,y,z]]
+    q1 : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
     """
-
-    q0 = q0.clone()
-    q1 = q1.clone()
     w0, x0, y0, z0 = q0[..., 0:1], q0[..., 1:2], q0[..., 2:3], q0[..., 3:4]
     w1, x1, y1, z1 = q1[..., 0:1], q1[..., 1:2], q1[..., 2:3], q1[..., 3:4]
     # (w0,v0)(w1,v1) = (w0w1 - v0·v1, w0v1 + w1v0 + v0 x v1)
-    return torch.cat(
+    return np.concatenate(
         (
             w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1,  # w
             w0 * x1 + w1 * x0 + y0 * z1 - z0 * y1,  # x
             w0 * y1 + w1 * y0 + z0 * x1 - x0 * z1,  # y
             w0 * z1 + w1 * z0 + x0 * y1 - y0 * x1,  # z
         ),
-        dim=-1,
+        axis=-1,
     )
 
 
-def length(quaternions: torch.Tensor) -> torch.Tensor:
+def length(quaternions: np.array) -> np.array:
     """
     Get the length or magnitude of the quaternions.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    length : torch.Tensor[...]
+    length : np.array[...]
     """
-    return torch.linalg.norm(quaternions, dim=-1)
+    return np.linalg.norm(quaternions, axis=-1)
 
 
-def inverse(quaternions: torch.Tensor) -> torch.Tensor:
+def inverse(quaternions: np.array) -> np.array:
     """
     Inverse of a quaternion.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
     """
     # for a unit quaternion the conjugate is the inverse
     # q^-1 = [q0, -q1, -q2, -q3]
     return conjugate(quaternions)
 
 
-def conjugate(quaternions: torch.Tensor) -> torch.Tensor:
+def conjugate(quaternions: np.array) -> np.array:
     """
     Compute the conjugate of a quaternion.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
     """
-    return torch.cat((quaternions[..., 0:1], -quaternions[..., 1:]), dim=-1)
+    return np.concatenate((quaternions[..., 0:1], -quaternions[..., 1:]), axis=-1)
 
 
-def normalize(quaternions: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+def normalize(quaternions: np.array, eps: float = 1e-8) -> np.array:
     """
     Convert all quaternions to unit quatenrions.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
     """
-    return quaternions / (length(quaternions).unsqueeze(-1) + eps)
+    return quaternions / (length(quaternions)[..., np.newaxis] + eps)
 
 
-def unroll(quaternions: torch.Tensor, dim: int) -> torch.Tensor:
+def unroll(quaternions: np.array, axis: int) -> np.array:
     """
     Avoid the quaternion 'double cover' problem by picking the cover
     of the first quaternion, and then removing sudden switches
@@ -472,19 +461,19 @@ def unroll(quaternions: torch.Tensor, dim: int) -> torch.Tensor:
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
-    dim : int
-        unroll dimension (e.g., frames dimension)
+    quaternions : np.array[..., [w,x,y,z]]
+    axis : int
+        unroll axis (e.g., frames axis)
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
     """
-    r = quaternions.swapaxes(0, dim)
+    r = quaternions.swapaxes(0, axis)
 
     # Vectorized approach: compute all dot products between consecutive quaternions
     # Shape: (n-1, ...) where n is the number of frames
-    dots = torch.sum(r[1:] * r[:-1], dim=-1)
+    dots = np.sum(r[1:] * r[:-1], axis=-1)
 
     # Determine which frames should be flipped (where dot product is negative)
     # Negative dot product means the flipped version is closer
@@ -492,87 +481,85 @@ def unroll(quaternions: torch.Tensor, dim: int) -> torch.Tensor:
 
     # Convert to signs: -1 for flip, 1 for no flip
     # Shape: (n-1, ...)
-    flip_signs = torch.where(should_flip, torch.tensor(-1, dtype=r.dtype, device=r.device),
-                             torch.tensor(1, dtype=r.dtype, device=r.device))
+    flip_signs = np.where(should_flip, -1, 1)
 
     # Compute cumulative product to get the accumulated flip for each frame
     # This propagates flips: if frame i is flipped and frame i+1 should flip
     # relative to i, then frame i+1 gets flipped twice (back to original sign)
     # Shape: (n-1, ...)
-    cumulative_flips = torch.cumprod(flip_signs, dim=0)
+    cumulative_flips = np.cumprod(flip_signs, axis=0)
 
-    # Create full array of flips including the first frame (which never flips)
-    # Avoid in-place operations to preserve gradients
-    # Shape: (n, ...)
-    all_flips = torch.ones(r.shape[:-1], dtype=cumulative_flips.dtype, device=r.device)
-    all_flips = torch.cat([all_flips[:1], cumulative_flips], dim=0)
+    # Apply flips directly to r[1:] (first frame never flips)
+    # Broadcasting over the last dimension (quaternion components)
+    r[1:] = r[1:] * cumulative_flips[..., np.newaxis]
 
-    # Apply flips by broadcasting over the last dimension (quaternion components)
-    r = r * all_flips.unsqueeze(-1)
-
-    r = r.swapaxes(0, dim)
+    r = r.swapaxes(0, axis)
     return r
 
 
-def slerp(q0: torch.Tensor, q1: torch.Tensor, t: float | torch.Tensor, shortest: bool = True) -> torch.Tensor:
+def slerp(
+    q0: np.array, q1: np.array, t: float | np.array, shortest: bool = True
+) -> np.array:
     """
     Perform spherical linear interpolation (SLERP) between two unit quaternions.
 
     Parameters
     ----------
-    q0 : torch.Tensor[..., [w,x,y,z]]
-    q1 : torch.Tensor[..., [w,x,y,z]]
-    t : float or torch.Tensor[..., [t]]
+    q0 : np.array[..., [w,x,y,z]]
+    q1 : np.array[..., [w,x,y,z]]
+    t : float or np.array[..., [t]]
         Interpolation parameter between 0 and 1. At t=0, returns q0 and at t=1, returns q1.
     shorthest : bool
         Ensure the shorthest path between quaternions.
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
     """
-
     # Compute the cosine of the angle between the two vectors.
-    dot = torch.sum(q0 * q1, dim=-1, keepdim=True)
+    dot = np.sum(q0 * q1, axis=-1, keepdims=True)
 
     # If the dot product is negative, the quaternions
     # have opposite handed-ness and slerp won't take
     # the shorter path. Fix by reversing one quaternion.
-    if shortest:
-        q1 = torch.where(dot < 0, -q1, q1)
-        dot = torch.where(dot < 0, -dot, dot)
+    q1 = np.where(shortest and dot < 0, -q1, q1)
+    dot = np.where(shortest and dot < 0, -dot, dot)
 
     # Clamp to prevent instability at near 180° angle
-    dot = torch.clip(dot, -1, 1)
+    dot = np.clip(dot, -1, 1)
 
     # Compute the quaternion of the angle between the quaternions
-    theta_0 = torch.arccos(dot)  # theta_0 = angle between input vectors
+    theta_0 = np.arccos(dot)  # theta_0 = angle between input vectors
     theta = theta_0 * t  # theta = angle between q0 vector and result
 
     q2 = q1 - q0 * dot
-    q2 /= torch.linalg.norm(q2 + 0.000001, dim=-1, keepdim=True)  # {q0, q2} is now an orthonormal basis
+    q2 /= np.linalg.norm(
+        q2 + 0.000001, axis=-1, keepdims=True
+    )  # {q0, q2} is now an orthonormal basis
 
-    return torch.cos(theta) * q0 + torch.sin(theta) * q2
+    return np.cos(theta) * q0 + np.sin(theta) * q2
 
 
-def from_to(v1: torch.Tensor, v2: torch.Tensor, normalize_input: bool = True) -> torch.Tensor:
+def from_to(v1: np.ndarray, v2: np.ndarray, normalize_input: bool = True) -> np.ndarray:
     """
-    Calculate the quaternion that rotates direction v1 to direction v2 using PyTorch.
+    Calculate the quaternion that rotates direction v1 to direction v2.
     When v1 and v2 are parallel, the result is the identity quaternion.
 
     Parameters
     ----------
-    v1, v2 : torch.Tensor[..., [x,y,z]]
+    v1, v2 : np.array[..., [x,y,z]]
         Input vectors representing directions.
     normalize_input : bool
         Whether to normalize the input vectors.
 
     Returns
     -------
-    rot : torch.Tensor[..., [w,x,y,z]]
+    rot : np.array[..., [w,x,y,z]]
         Quaternion representing the rotation.
     """
-    assert v1.shape[-1] == 3 and v2.shape[-1] == 3, "Input vectors must have shape [..., 3]"
+    assert (
+        v1.shape[-1] == 3 and v2.shape[-1] == 3
+    ), "Input vectors must have shape [..., 3]"
     assert v1.shape == v2.shape, "Input vectors must have the same shape"
 
     if normalize_input:
@@ -583,63 +570,69 @@ def from_to(v1: torch.Tensor, v2: torch.Tensor, normalize_input: bool = True) ->
         v2_norm = v2
 
     if v1.ndim == 1:
-        v1_norm = v1_norm.unsqueeze(0)
-        v2_norm = v2_norm.unsqueeze(0)
+        v1_norm = v1_norm[np.newaxis, :]
+        v2_norm = v2_norm[np.newaxis, :]
 
     # Calculate cross product and dot product
-    cross = torch.linalg.cross(v1_norm, v2_norm)
-    dot = torch.sum(v1_norm * v2_norm, dim=-1, keepdim=True)
+    cross = np.cross(v1_norm, v2_norm)
+    dot = np.sum(v1_norm * v2_norm, axis=-1, keepdims=True)
 
     # Handle general case
     axis_rot = normalize(cross)
-    w = torch.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
-    s = torch.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
-    rot = torch.cat([w, axis_rot * s], dim=-1)
+    w = np.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
+    s = np.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
+    rot = np.concatenate([w, axis_rot * s], axis=-1)
 
     # Handle parallel vectors (dot ≈ 1)
-    parallel_mask = torch.isclose(dot, torch.tensor(1.0, device=rot.device, dtype=rot.dtype))
-    identity_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], device=rot.device, dtype=rot.dtype)
-    rot[parallel_mask[..., 0]] = identity_quat
+    parallel = np.isclose(dot, 1.0)
+    rot[parallel[..., 0]] = [1.0, 0.0, 0.0, 0.0]
 
     # Handle anti-parallel vectors (dot ≈ -1)
-    anti_parallel_mask = torch.isclose(dot, torch.tensor(-1.0, device=rot.device, dtype=rot.dtype))[..., 0]
+    anti_parallel_mask = np.isclose(dot, -1.0)[..., 0]
 
-    if torch.any(anti_parallel_mask):  # Check if any anti-parallel vectors exist
-        v1_anti_parallel = v1_norm[anti_parallel_mask]  # Extract anti-parallel v1 vectors
+    if np.any(anti_parallel_mask):  # Check if any anti-parallel vectors exist
+        v1_anti_parallel = v1_norm[
+            anti_parallel_mask
+        ]  # Extract anti-parallel v1 vectors
 
         # Vectorized orthogonal vector selection
-        orthogonal_anti_parallel = torch.empty_like(v1_anti_parallel)  # Initialize with correct shape
-        condition_mask = torch.isclose(
-            torch.abs(v1_anti_parallel[..., 0]), torch.tensor(1.0, device=rot.device, dtype=rot.dtype)
+        orthogonal_anti_parallel = np.empty_like(
+            v1_anti_parallel
+        )  # Initialize with correct shape
+        condition_mask = np.isclose(
+            np.abs(v1_anti_parallel[..., 0]), 1.0
         )  # Boolean mask
 
-        orthogonal_anti_parallel[condition_mask] = torch.tensor(
-            [0.0, 1.0, 0.0], device=rot.device, dtype=rot.dtype
+        orthogonal_anti_parallel[condition_mask] = np.array(
+            [0.0, 1.0, 0.0]
         )  # Assign for True condition
-        orthogonal_anti_parallel[~condition_mask] = torch.tensor(
-            [1.0, 0.0, 0.0], device=rot.device, dtype=rot.dtype
+        orthogonal_anti_parallel[~condition_mask] = np.array(
+            [1.0, 0.0, 0.0]
         )  # Assign for False condition
 
         # Vectorized axis of rotation calculation
-        axis_rot_anti_parallel = normalize(torch.linalg.cross(v1_anti_parallel, orthogonal_anti_parallel))
+        axis_rot_anti_parallel = normalize(
+            np.cross(v1_anti_parallel, orthogonal_anti_parallel)
+        )
 
         # Vectorized quaternion construction for anti-parallel case
-        rot_correction_anti_parallel = torch.cat(
-            [torch.zeros_like(axis_rot_anti_parallel[..., :1]), axis_rot_anti_parallel], dim=-1
+        rot_correction_anti_parallel = np.concatenate(
+            [np.zeros_like(axis_rot_anti_parallel[..., :1]), axis_rot_anti_parallel],
+            axis=-1,
         )
 
         # Vectorized assignment of corrections
         rot[anti_parallel_mask] = rot_correction_anti_parallel
 
     if v1.ndim == 1:
-        rot = rot.squeeze(0)
+        rot = rot[0]
 
     return rot
 
 
 def from_to_axis(
-    v1: torch.Tensor, v2: torch.Tensor, rot_axis: torch.Tensor, normalize_input: bool = True
-) -> torch.Tensor:
+    v1: np.ndarray, v2: np.ndarray, rot_axis: np.ndarray, normalize_input: bool = True
+) -> np.ndarray:
     """
     Calculate the quaternion that rotates direction v1 to direction v2.
     The rotation axis is fixed to the provided axis.
@@ -647,24 +640,28 @@ def from_to_axis(
 
     Parameters
     ----------
-    v1, v2 : torch.Tensor[..., [x,y,z]]
+    v1, v2 : np.array[..., [x,y,z]]
         Input vectors representing directions.
-    rot_axis : torch.Tensor[..., [x,y,z]]
+    axis : np.array[..., [x,y,z]]
         Fixed rotation axis.
     normalize_input : bool
         Whether to normalize the input vectors.
 
     Returns
     -------
-    rot : torch.Tensor[..., [w,x,y,z]]
+    rot : np.array[..., [w,x,y,z]]
         Quaternion representing the rotation.
     """
-    assert v1.shape[-1] == 3 and v2.shape[-1] == 3, "Input vectors must have shape [..., 3]"
+    assert (
+        v1.shape[-1] == 3 and v2.shape[-1] == 3
+    ), "Input vectors must have shape [..., 3]"
     assert v1.shape == v2.shape, "Input vectors must have the same shape"
-    assert v1.shape == rot_axis.shape, "Input vectors must have the same shape"
+    assert (
+        v1.shape == rot_axis.shape
+    ), "Input vectors and rotation axis must have the same shape"
 
     if rot_axis.ndim == 1:
-        rot_axis = rot_axis.unsqueeze(0)
+        rot_axis = rot_axis[np.newaxis, :]
 
     if normalize_input:
         v1_norm = vec.normalize(v1)
@@ -674,65 +671,66 @@ def from_to_axis(
         v2_norm = v2
 
     if v1.ndim == 1:
-        v1_norm = v1_norm.unsqueeze(0)
-        v2_norm = v2_norm.unsqueeze(0)
+        v1_norm = v1_norm[np.newaxis, :]
+        v2_norm = v2_norm[np.newaxis, :]
 
     # Calculate cross product and dot product
-    cross = torch.cross(v1_norm, v2_norm, dim=-1)
-    dot = torch.sum(v1_norm * v2_norm, dim=-1, keepdim=True)
+    cross = np.cross(v1_norm, v2_norm)
+    dot = np.sum(v1_norm * v2_norm, axis=-1, keepdims=True)
 
     # Handle general case
-    w = torch.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
-    s = torch.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
+    w = np.sqrt((1 + dot) * 0.5)  # cos(theta/2) = sqrt((1 + dot) / 2)
+    s = np.sqrt((1 - dot) * 0.5)  # sin(theta/2) = sqrt((1 - dot) / 2)
     # Adjust sign of s based on cross product and rot_axis
-    cross_dot_axis = torch.sum(cross * rot_axis, dim=-1, keepdim=True)
-    s *= torch.sign(cross_dot_axis)  # Correct sign based on alignment
+    cross_dot_axis = np.sum(cross * rot_axis, axis=-1, keepdims=True)
+    s *= np.sign(cross_dot_axis)  # Correct sign based on alignment
     # Combine w and s to form quaternion
-    rot = torch.cat([w, rot_axis * s], dim=-1)
+    rot = np.concatenate([w, rot_axis * s], axis=-1)
 
     # Handle parallel vectors (dot ≈ 1)
-    parallel_mask = torch.isclose(dot, torch.tensor(1.0, device=rot.device, dtype=rot.dtype))
-    identity_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], device=rot.device, dtype=rot.dtype)
-    rot[parallel_mask[..., 0]] = identity_quat
+    parallel = np.isclose(dot, 1.0)
+    rot[parallel[..., 0]] = [1.0, 0.0, 0.0, 0.0]
 
     # Handle anti-parallel vectors (dot ≈ -1)
-    anti_parallel = torch.isclose(dot, torch.tensor(-1.0, device=rot.device, dtype=rot.dtype))
-    anti_parallel_rotmask = torch.tile(anti_parallel, (1,) * (rot.ndim - 1) + (4,))
-    anti_parallel_rotaxismask = torch.tile(anti_parallel, (1,) * (rot_axis.ndim - 1) + (3,))
+    anti_parallel = np.isclose(dot, -1.0)
+    anti_parallel_rotmask = np.tile(anti_parallel, (1,) * (rot.ndim - 1) + (4,))
+    anti_parallel_rotaxismask = np.tile(
+        anti_parallel, (1,) * (rot_axis.ndim - 1) + (3,)
+    )
     rots_anti_parallel = rot[anti_parallel_rotmask]
     rots_anti_parallel[::4] = 0
-    rots_anti_parallel[[False, True, True, True] * (len(rots_anti_parallel) // 4)] = rot_axis[
-        anti_parallel_rotaxismask
-    ]
+    rots_anti_parallel[[False, True, True, True] * (len(rots_anti_parallel) // 4)] = (
+        rot_axis[anti_parallel_rotaxismask]
+    )
     rot[anti_parallel_rotmask] = rots_anti_parallel
 
     if v1.ndim == 1:
-        rot = rot.squeeze(0)
+        rot = rot[0]
 
     return rot
 
 
 def weighted_slerp(
-    quaternions: torch.Tensor, weights: torch.Tensor, shortest: bool = True
-) -> torch.Tensor:
+    quaternions: np.array, weights: np.array, shortest: bool = True
+) -> np.array:
     """
     Perform weighted spherical linear interpolation (SLERP) across multiple quaternions.
     Uses iterative weighted SLERP to properly blend quaternions based on their weights.
 
     Parameters
     ----------
-    quaternions : torch.Tensor[num_items, ..., [w,x,y,z]]
+    quaternions : np.array[num_items, ..., [w,x,y,z]]
         Quaternions to blend. First dimension is the items to blend.
         For batch processing, use shape [batch, num_items, ..., [w,x,y,z]] and call this
-        function in a loop or use vmap.
-    weights : torch.Tensor[num_items]
+        function in a loop.
+    weights : np.array[num_items]
         Weights for each quaternion. Must sum to approximately 1.0 for meaningful results.
     shortest : bool, optional
         Ensure the shortest path between quaternions. Default is True.
 
     Returns
     -------
-    quat : torch.Tensor[..., [w,x,y,z]]
+    quat : np.array[..., [w,x,y,z]]
         Weighted blend of input quaternions
 
     Notes
@@ -748,29 +746,29 @@ def weighted_slerp(
 
     Examples
     --------
-    >>> import torch
+    >>> import numpy as np
     >>> import pymotion.rotations.quat as quat
     >>>
     >>> # Define 3 quaternions (identity, 90° around Z, 180° around Z)
-    >>> quaternions = torch.tensor([
+    >>> quaternions = np.array([
     ...     [1.0, 0.0, 0.0, 0.0],  # identity
     ...     [0.707, 0.0, 0.0, 0.707],  # 90° Z
     ...     [0.0, 0.0, 0.0, 1.0],  # 180° Z
     ... ])
-    >>> weights = torch.tensor([0.3, 0.5, 0.2])
+    >>> weights = np.array([0.3, 0.5, 0.2])
     >>> result = quat.weighted_slerp(quaternions, weights)
     >>>
     >>> # For batch processing with different weights, call in a loop:
-    >>> weights_batch = torch.tensor([[0.3, 0.5, 0.2], [0.6, 0.2, 0.2]])
-    >>> results = torch.stack([
+    >>> weights_batch = np.array([[0.3, 0.5, 0.2], [0.6, 0.2, 0.2]])
+    >>> results = np.stack([
     ...     quat.weighted_slerp(quaternions, w) for w in weights_batch
     ... ])
     """
     num_items = quaternions.shape[0]
 
     # Initialize with first quaternion
-    result = quaternions[0].clone()  # [..., 4]
-    accumulated_weight = weights[0].clone()
+    result = quaternions[0].copy()  # [..., 4]
+    accumulated_weight = weights[0].copy()
 
     # Iteratively SLERP with each subsequent quaternion
     for i in range(1, num_items):
@@ -783,7 +781,7 @@ def weighted_slerp(
     return result
 
 
-def canonicalize(quaternions: torch.Tensor) -> torch.Tensor:
+def canonicalize(quaternions: np.array) -> np.array:
     """
     Convert quaternions to canonical form where w >= 0.
 
@@ -791,16 +789,13 @@ def canonicalize(quaternions: torch.Tensor) -> torch.Tensor:
     use the same hemisphere. This is important before operations like scaling
     the rotation angle, as it ensures the shortest rotation path is used.
 
-    The operation is fully differentiable. Gradients flow through correctly
-    as torch.where selects which branch to use for both forward and backward pass.
-
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
         Quaternions with w >= 0 (same rotation, canonical representation)
 
     Notes
@@ -812,14 +807,14 @@ def canonicalize(quaternions: torch.Tensor) -> torch.Tensor:
 
     Examples
     --------
-    >>> q = torch.tensor([[-0.707, 0.0, 0.707, 0.0]])  # w < 0
+    >>> q = np.array([[-0.707, 0.0, 0.707, 0.0]])  # w < 0
     >>> q_canonical = canonicalize(q)
     >>> print(q_canonical)  # [0.707, 0.0, -0.707, 0.0], same rotation but w >= 0
     """
-    return torch.where(quaternions[..., 0:1] < 0, -quaternions, quaternions)
+    return np.where(quaternions[..., 0:1] < 0, -quaternions, quaternions)
 
 
-def scale(quaternions: torch.Tensor, factor: float | torch.Tensor) -> torch.Tensor:
+def scale(quaternions: np.array, factor: float | np.array) -> np.array:
     """
     Scale quaternion rotations by a factor.
 
@@ -832,16 +827,16 @@ def scale(quaternions: torch.Tensor, factor: float | torch.Tensor) -> torch.Tens
 
     Parameters
     ----------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
         Input quaternions to scale.
-    factor : float or torch.Tensor
+    factor : float or np.array
         Scale factor for the rotation angle. Can be:
         - A scalar (applies same scale to all quaternions)
-        - A tensor broadcastable to quaternions shape (for per-element scaling)
+        - An array broadcastable to quaternions shape (for per-element scaling)
 
     Returns
     -------
-    quaternions : torch.Tensor[..., [w,x,y,z]]
+    quaternions : np.array[..., [w,x,y,z]]
         Scaled quaternions.
 
     Notes
@@ -854,14 +849,14 @@ def scale(quaternions: torch.Tensor, factor: float | torch.Tensor) -> torch.Tens
 
     Examples
     --------
-    >>> q = torch.tensor([[0.707, 0.0, 0.707, 0.0]])  # 90° rotation around Y
+    >>> q = np.array([[0.707, 0.0, 0.707, 0.0]])  # 90° rotation around Y
     >>> q_half = scale(q, 0.5)  # 45° rotation around Y
     >>> q_double = scale(q, 2.0)  # 180° rotation around Y
 
     >>> # Per-joint scaling
-    >>> q = torch.randn(10, 22, 4)  # 10 frames, 22 joints
+    >>> q = np.random.randn(10, 22, 4)  # 10 frames, 22 joints
     >>> q = normalize(q)
-    >>> joint_scales = torch.rand(22, 1)  # Different scale per joint
+    >>> joint_scales = np.random.rand(22, 1)  # Different scale per joint
     >>> q_scaled = scale(q, joint_scales)
     """
     # Canonicalize to ensure shortest rotation path (w >= 0)
@@ -872,25 +867,25 @@ def scale(quaternions: torch.Tensor, factor: float | torch.Tensor) -> torch.Tens
     return from_scaled_angle_axis(scaled_axis)
 
 
-def _fast_cross(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+def _fast_cross(a: np.array, b: np.array) -> np.array:
     """
     Fast cross of two vectors
 
     Parameters
     ----------
-    a : torch.Tensor[..., [x,y,z]]
-    b : torch.Tensor[..., [x,y,z]]
+    a : np.array[..., [x,y,z]]
+    b : np.array[..., [x,y,z]]
 
     Returns
     -------
-    torch.Tensor[..., [x,y,z]]
+    np.array[..., [x,y,z]]
     """
 
-    return torch.cat(
+    return np.concatenate(
         [
             a[..., 1:2] * b[..., 2:3] - a[..., 2:3] * b[..., 1:2],
             a[..., 2:3] * b[..., 0:1] - a[..., 0:1] * b[..., 2:3],
             a[..., 0:1] * b[..., 1:2] - a[..., 1:2] * b[..., 0:1],
         ],
-        dim=-1,
+        axis=-1,
     )

--- a/pymotion/rotations/tests/test_ortho6d.py
+++ b/pymotion/rotations/tests/test_ortho6d.py
@@ -41,9 +41,9 @@ class TestOrtho6D:
         t_q_t = torch.cat([torch.from_numpy(q_id), q2_t], dim=-2)
         q = np.concatenate([q_id, q], axis=-2)
         q_t = torch.cat([torch.from_numpy(q_id), q_t], dim=-2)
-        t_q = quat.unroll(t_q, axis=-2)
+        t_q = quat.unroll(t_q, dim=-2)
         t_q_t = quat_torch.unroll(t_q_t, dim=-2)
-        q = quat.unroll(q, axis=-2)
+        q = quat.unroll(q, dim=-2)
         q_t = quat_torch.unroll(q_t, dim=-2)
         # create rotation matrices from ortho6D
         r2 = sixd.to_matrix(o)

--- a/pymotion/rotations/tests/test_quat.py
+++ b/pymotion/rotations/tests/test_quat.py
@@ -4,7 +4,6 @@ import numpy as np
 import torch
 from numpy.testing import assert_allclose
 
-
 # This code lets you see the effect of unrolling a quaternion
 # import matplotlib.pyplot as plt  # uncomment this line to see the effect of unrolling a quaternion
 # def test_unroll(qs, joint=0):
@@ -14,7 +13,7 @@ from numpy.testing import assert_allclose
 #     ax0.plot(range(qs.shape[-3]), qs[..., joint, 2], label="y")
 #     ax0.plot(range(qs.shape[-3]), qs[..., joint, 3], label="z")
 #     ax0.set_title("Input")
-#     qs_unrolled = quat.unroll(qs, axis=-3)
+#     qs_unrolled = quat.unroll(qs, dim=-3)
 #     ax1.plot(range(qs.shape[-3]), qs_unrolled[..., joint, 0], label="w")
 #     ax1.plot(range(qs.shape[-3]), qs_unrolled[..., joint, 1], label="x")
 #     ax1.plot(range(qs.shape[-3]), qs_unrolled[..., joint, 2], label="y")
@@ -25,7 +24,7 @@ from numpy.testing import assert_allclose
 
 
 class TestQuat:
-    atol = 1e-6
+    atol = 1e-5
     low_atol = 1e-3  # for those operations that are not as precise
 
     def test_angle_axis(self):
@@ -46,10 +45,10 @@ class TestQuat:
         # check if inverse operations produce the same result
         t_angle, t_axis = quat.to_angle_axis(q)
         t_angle_t, t_axis_t = quat_torch.to_angle_axis(q_t)
-        assert_allclose(t_angle, angle, atol=self.atol)
-        assert_allclose(t_axis, axis, atol=self.atol)
-        assert_allclose(t_angle_t.numpy(), angle, atol=self.atol)
-        assert_allclose(t_axis_t.numpy(), axis, atol=self.atol)
+        assert_allclose(t_angle, angle, atol=self.low_atol)
+        assert_allclose(t_axis, axis, atol=self.low_atol)
+        assert_allclose(t_angle_t.numpy(), angle, atol=self.low_atol)
+        assert_allclose(t_axis_t.numpy(), axis, atol=self.low_atol)
         # simple samples
         axis = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
         axis_t = torch.from_numpy(axis)
@@ -71,10 +70,10 @@ class TestQuat:
         q_t = torch.from_numpy(ground_truth)
         t_angle, t_axis = quat.to_angle_axis(q)
         t_angle_t, t_axis_t = quat_torch.to_angle_axis(q_t)
-        assert_allclose(t_angle, angle, atol=self.atol)
-        assert_allclose(t_axis, axis, atol=self.atol)
-        assert_allclose(t_angle_t.numpy(), angle, atol=self.atol)
-        assert_allclose(t_axis_t.numpy(), axis, atol=self.atol)
+        assert_allclose(t_angle, angle, atol=self.low_atol)
+        assert_allclose(t_axis, axis, atol=self.low_atol)
+        assert_allclose(t_angle_t.numpy(), angle, atol=self.low_atol)
+        assert_allclose(t_axis_t.numpy(), axis, atol=self.low_atol)
 
     def test_scaled_angle_axis(self):
         n = 100
@@ -196,9 +195,9 @@ class TestQuat:
         t_q = np.concatenate([q_id, t_q], axis=-2)
         t_q_t = np.concatenate([q_id, t_q_t.numpy()], axis=-2)
         q = np.concatenate([q_id, q], axis=-2)
-        t_q = quat.unroll(t_q, axis=-2)
-        t_q_t = quat.unroll(t_q_t, axis=-2)
-        q = quat.unroll(q, axis=-2)
+        t_q = quat.unroll(t_q, dim=-2)
+        t_q_t = quat.unroll(t_q_t, dim=-2)
+        q = quat.unroll(q, dim=-2)
         assert_allclose(t_q, q, atol=self.atol)
         assert_allclose(t_q_t, q, atol=self.atol)
         # simple samples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = ["*test*"]
 
 [project]
 name = "upc-pymotion"
-version = "0.2.3"
+version = "0.3.0"
 description = "A Python library for working with motion data in NumPy or PyTorch."
 readme = "README.md"
 authors = [{ name = "Jose Luis Ponton", email = "jose.luis.ponton@upc.edu" }]


### PR DESCRIPTION
Refactor rotations (quat, dual_quat, ortho6d) and ops (skeleton, center_of_mass, time, vector) into unified wrappers that dispatch to NumPy or PyTorch backends, with new *_np.py backend modules. Update io/bvh.py and the render utilities. Add copyright headers (full for new files, Portions for modified files) for the work done during the internship at Meta.